### PR TITLE
add dropout in neg sampling in other trainmodes

### DIFF
--- a/src/doc_data.cpp
+++ b/src/doc_data.cpp
@@ -175,7 +175,7 @@ void LayerDataHandler::getRandomRHS(vector<int32_t>& result) const {
     int wid = rand() % ex.RHSFeatures[r].size();
     result.push_back(ex.RHSFeatures[r][wid]);
   } else {
-    insert(result, ex.RHSFeatures[r]);
+    insert(result, ex.RHSFeatures[r], args_->dropoutRHS);
   }
 }
 


### PR DESCRIPTION
RHS dropout was missing in some train mode in neg sampling. This fixes it.