### PR TITLE
Support output embedding vectors for sentence / documents

### DIFF
--- a/makefile
+++ b/makefile
@@ -107,6 +107,9 @@ query_nn: $(OBJS)
 print_ngrams: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) $(INCLUDES) -g src/apps/print_ngrams.cpp -o print_ngrams
 
+embed_doc: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(OBJS) $(INCLUDES) -g src/apps/embed_doc.cpp -o embed_doc
+
 test: $(TESTS)
 
 clean:

--- a/src/apps/embed_doc.cpp
+++ b/src/apps/embed_doc.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "../starspace.h"
+#include <iostream>
+#include <boost/algorithm/string/predicate.hpp>
+
+using namespace std;
+using namespace starspace;
+
+// Read each sentence / document line by line,
+// and output it's embedding vector
+voiid embedDoc(StarSpace& sp, istream& fin) {
+  string input;
+  while (getline(fin, input)) {
+    if (input.size() ==0) break;
+    cout << input << endl;
+    auto vec = sp.getDocVector(input);
+    vec.forEachCell([&](Real r) { cout << r << ' '; });
+    cout << endl;
+  }
+}
+
+int main(int argc, char** argv) {
+  shared_ptr<Args> args = make_shared<Args>();
+
+  if (argc < 2) {
+    cerr << "usage: " << argv[0] << " <model> [filename]\n";
+    cerr << "if filename is specified, it reads each line from the file and"
+         << "output corresponding vectors";
+    return 1;
+  }
+
+  std::string model(argv[1]);
+  args->model = model;
+
+  StarSpace sp(args);
+  sp.initFromSavedModel(args->model);
+  // set useWeight by default.
+  // use 1.0 for default weight if weight is not found
+  args->useWeight = true;
+
+  if (argc > 2) {
+    std::string filename(argv[2]);
+    ifstream fin(filename);
+    if (!fin.is_open()) {
+      std::cerr << "file cannot be opened for loading!" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    embedDoc(sp, fin);
+    fin.close();
+  } else {
+    cout << "Input your sentence / document now:\n";
+    embedDoc(sp, cin);
+  }
+
+  return 0;
+}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -152,6 +152,15 @@ bool DataParser::parse(
 
   for (auto &token: tokens) {
     auto t = token;
+    float weight = 1.0;
+    if (args_->useWeight) {
+      std::size_t pos = token.find(":");
+      if (pos != std::string::npos) {
+        t = token.substr(0, pos);
+        weight = atof(token.substr(pos + 1).c_str());
+      }
+    }
+
     if (args_->normalizeText) {
       normalize_text(t);
     }
@@ -162,7 +171,7 @@ bool DataParser::parse(
 
     entry_type type = dict_->getType(wid);
     if (type == entry_type::word) {
-      rslts.push_back(make_pair(wid, 1.0));
+      rslts.push_back(make_pair(wid, weight));
     }
   }
 

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -199,7 +199,7 @@ void StarSpace::parseDoc(
 Matrix<Real> StarSpace::getDocVector(const string& line, const string& sep) {
   vector<Base> ids;
   parseDoc(line, ids, sep);
-  return model_->projectRHS(ids);
+  return model_->projectLHS(ids);
 }
 
 MatrixRow StarSpace::getNgramVector(const string& phrase) {

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -33,7 +33,9 @@ class StarSpace {
     void evaluate();
 
     MatrixRow getNgramVector(const std::string& phrase);
-    Matrix<Real> getDocVector(const std::string& line, const std::string& sep);
+    Matrix<Real> getDocVector(
+        const std::string& line,
+        const std::string& sep = " \t");
     void parseDoc(
         const std::string& line,
         std::vector<Base>& ids,


### PR DESCRIPTION
As requested in https://github.com/facebookresearch/StarSpace/issues/84, this diff adds a feature to embed sentence/document given a trained model. Usage:
`make embed_doc`
`./embed_doc <model> [filename]`

If [filename] is not specified, it uses default cin as input, and reads each sentence/document line by line,  output its vector embedding accordingly.
