### PR TITLE
Proper warning for testing in trainMode 5

### DIFF
--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -334,6 +334,12 @@ void StarSpace::printDoc(ofstream& ofs, const vector<Base>& tokens) {
 }
 
 void StarSpace::evaluate() {
+  // check that it is not in trainMode 5
+  if (args_->trainMode == 5) {
+    std::cerr << "Test is undefined in trainMode 5. Please use other trainMode for testing.\n";
+    exit(EXIT_FAILURE);
+  }
+
   // set dropout probability to 0 in test case
   args_->dropoutLHS = 0.0;
   args_->dropoutRHS = 0.0;


### PR DESCRIPTION
Testing in trainMode 5 (word level training) is undefined. This adds a proper warning for such case.
