### PR TITLE
More accurate error messages on invalid examples

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -26,6 +26,15 @@ InternDataHandler::InternDataHandler(shared_ptr<Args> args) {
   args_= args;
 }
 
+void InternDataHandler::errorOnZeroExample(const string& fileName) {
+  std::cerr << "ERROR: File '" << fileName
+            << "' does not contain any valid example.\n"
+            << "Please check: is the file empty? "
+            << "Do the examples contain proper feature and label according to the trainMode? "
+            << "If your examples are unlabeled, try to set trainMode=5.\n";
+  exit(EXIT_FAILURE);
+}
+
 void InternDataHandler::loadFromFile(
   const string& fileName,
   shared_ptr<DataParser> parser) {
@@ -62,8 +71,7 @@ void InternDataHandler::loadFromFile(
   cout << "Total number of examples loaded : " << examples_.size() << endl;
   size_ = examples_.size();
   if (size_ == 0) {
-    std::cerr << "ERROR: File '" << fileName << "' is empty." << std::endl;
-    exit(EXIT_FAILURE);
+    errorOnZeroExample(fileName);
   }
 }
 

--- a/src/data.h
+++ b/src/data.h
@@ -51,6 +51,8 @@ public:
 
   size_t getSize() const { return size_; };
 
+  void errorOnZeroExample(const std::string& fileName);
+
 
 protected:
   static const int32_t MAX_VOCAB_SIZE = 10000000;

--- a/src/doc_data.cpp
+++ b/src/doc_data.cpp
@@ -59,8 +59,7 @@ void LayerDataHandler::loadFromFile(
   cout << "Total number of examples loaded : " << examples_.size() << endl;
   size_ = examples_.size();
   if (size_ == 0) {
-    std::cerr << "ERROR: File '" << fileName << "' is empty." << std::endl;
-    exit(EXIT_FAILURE);
+    errorOnZeroExample(fileName);
   }
 }
 


### PR DESCRIPTION
as in title. There could be various reasons why a train file does not contain any valid example. i.e. The file can be empty, or it does not contain proper feature label according to the set trainMode.