### PR TITLE
Improvements on training word level embeddings

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -214,26 +214,45 @@ void InternDataHandler::getNextKExamples(int K, vector<ParseResults>& c) {
   }
 }
 
+void InternDataHandler::getRandomWord(vector<Base>& result) {
+  result.push_back(word_negatives_[word_iter_]);
+  word_iter_++;
+  if (word_iter_ >= word_negatives_.size()) {
+    word_iter_ = 0;
+  }
+}
+
+void InternDataHandler::initWordNegatives() {
+  word_iter_ = 0;
+  word_negatives_.clear();
+  assert(size_ > 0);
+  for (int i = 0; i < MAX_WORD_NEGATIVES_SIZE; i++) {
+    word_negatives_.emplace_back(genRandomWord());
+  }
+}
+
+Base InternDataHandler::genRandomWord() const {
+  assert(size_ > 0);
+  auto& ex = examples_[rand() % size_];
+  int r = rand() % ex.LHSTokens.size();
+  return ex.LHSTokens[r];
+}
+
 // Randomly sample one example and randomly sample a label from this example
 // The result is usually used as negative samples in training
-void InternDataHandler::getRandomRHS(vector<Base>& results, bool trainWord) const {
+void InternDataHandler::getRandomRHS(vector<Base>& results) const {
   assert(size_ > 0);
   results.clear();
   auto& ex = examples_[rand() % size_];
-  if (args_->trainMode == 5 || trainWord) {
-    int r = rand() % ex.LHSTokens.size();
-    results.push_back(ex.LHSTokens[r]);
-  } else {
-    int r = rand() % ex.RHSTokens.size();
-    if (args_->trainMode == 2) {
-      for (int i = 0; i < ex.RHSTokens.size(); i++) {
-        if (i != r) {
-          results.push_back(ex.RHSTokens[i]);
-        }
+  int r = rand() % ex.RHSTokens.size();
+  if (args_->trainMode == 2) {
+    for (int i = 0; i < ex.RHSTokens.size(); i++) {
+      if (i != r) {
+        results.push_back(ex.RHSTokens[i]);
       }
-    } else {
-      results.push_back(ex.RHSTokens[r]);
     }
+  } else {
+    results.push_back(ex.RHSTokens[r]);
   }
 }
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -145,13 +145,12 @@ void InternDataHandler::getWordExamples(
 
   rslts.clear();
   for (int widx = 0; widx < doc.size(); widx++) {
-    int bc = rand() % args_->ws + 1;
     ParseResults rslt;
     rslt.LHSTokens.clear();
     rslt.RHSTokens.clear();
     rslt.RHSTokens.push_back(doc[widx]);
-    for (int i = max(widx - bc, 0);
-         i < min(size_t(widx + bc), doc.size()); i++) {
+    for (int i = max(widx - args_->ws, 0);
+         i < min(size_t(widx + args_->ws), doc.size()); i++) {
       if (i != widx) {
         rslt.LHSTokens.push_back(doc[i]);
       }

--- a/src/data.h
+++ b/src/data.h
@@ -26,7 +26,7 @@ public:
 
   virtual void convert(const ParseResults& example, ParseResults& rslt) const;
 
-  virtual void getRandomRHS(std::vector<Base>& results, bool trainWord = false)
+  virtual void getRandomRHS(std::vector<Base>& results)
     const;
 
   virtual void save(std::ostream& out);
@@ -53,15 +53,24 @@ public:
 
   void errorOnZeroExample(const std::string& fileName);
 
+  void initWordNegatives();
+  void getRandomWord(std::vector<Base>& result);
+
 
 protected:
+  virtual Base genRandomWord() const;
+
   static const int32_t MAX_VOCAB_SIZE = 10000000;
+  static const int32_t MAX_WORD_NEGATIVES_SIZE = 10000000;
 
   std::shared_ptr<Args> args_;
   std::vector<ParseResults> examples_;
 
   int32_t idx_ = -1;
   int32_t size_ = 0;
+
+  int32_t word_iter_;
+  std::vector<Base> word_negatives_;
 };
 
 }

--- a/src/doc_data.cpp
+++ b/src/doc_data.cpp
@@ -156,17 +156,22 @@ void LayerDataHandler::convert(
   }
 }
 
-void LayerDataHandler::getRandomRHS(vector<Base>& result, bool trainWord) const {
+// generate a random word from examples
+Base LayerDataHandler::genRandomWord() const {
+  assert(size_ > 0);
+  auto& ex = examples_[rand() % size_];
+  int r = rand() % ex.RHSFeatures.size();
+  int wid = rand() % ex.RHSFeatures[r].size();
+  return ex.RHSFeatures[r][wid];
+}
+
+void LayerDataHandler::getRandomRHS(vector<Base>& result) const {
   assert(size_ > 0);
   auto& ex = examples_[rand() % size_];
   int r = rand() % ex.RHSFeatures.size();
 
   result.clear();
-  if (args_->trainMode == 5 || trainWord) {
-    // pick random word
-    int wid = rand() % ex.RHSFeatures[r].size();
-    result.push_back(ex.RHSFeatures[r][wid]);
-  } else if (args_->trainMode == 2) {
+  if (args_->trainMode == 2) {
     // pick one random, the rest is rhs features
     for (int i = 0; i < ex.RHSFeatures.size(); i++) {
       if (i != r) {

--- a/src/doc_data.h
+++ b/src/doc_data.h
@@ -36,12 +36,13 @@ public:
   void loadFromFile(const std::string& file,
                     std::shared_ptr<DataParser> parser) override;
 
-  void getRandomRHS(std::vector<Base>& results, bool trainWord = false)
-    const override;
+  void getRandomRHS(std::vector<Base>& results) const override;
 
   void save(std::ostream& out) override;
 
 private:
+  Base genRandomWord() const override;
+
   void insert(
       std::vector<Base>& rslt,
       const std::vector<Base>& ex,

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -185,6 +185,10 @@ Real EmbedModel::train(shared_ptr<InternDataHandler> data,
     for (auto& idx: indices) idx = i++;
   }
   std::random_shuffle(indices.begin(), indices.end());
+
+  // Compute word negatives
+  data->initWordNegatives();
+
   // If we decrement after *every* sample, precision causes us to lose the
   // update.
   const int kDecrStep = 1000;
@@ -382,7 +386,11 @@ float EmbedModel::trainOne(shared_ptr<InternDataHandler> data,
 
     std::vector<Base> negLabels;
     do {
-      data->getRandomRHS(negLabels, trainWord);
+      if (trainWord) {
+        data->getRandomWord(negLabels);
+      } else {
+        data->getRandomRHS(negLabels);
+      }
     } while (negLabels == labels);
 
     projectRHS(negLabels, rhsN);
@@ -464,7 +472,11 @@ float EmbedModel::trainNLL(shared_ptr<InternDataHandler> data,
   for (int i = 1; i < numClass; i++) {
     std::vector<Base> negLabels;
     do {
-      data->getRandomRHS(negLabels, trainWord);
+      if (trainWord) {
+        data->getRandomWord(negLabels);
+      } else {
+        data->getRandomRHS(negLabels);
+      }
     } while (negLabels == labels);
     projectRHS(negLabels, rhsN);
     check(rhsN);


### PR DESCRIPTION
A couple of changes to speed up word level training (Issue https://github.com/facebookresearch/StarSpace/issues/132):
* do a random sliding window size which draws randomly from [1, args->ws]
* pre-sampling a list of word negatives at the beginning of each epoch of training

This leads to a ~30% speed up on benchmark dataset.
More optimizations to follow.
