### PR TITLE
adding excludeLHS flag

### DIFF
--- a/examples/recomm_user_artists.sh
+++ b/examples/recomm_user_artists.sh
@@ -87,4 +87,6 @@ echo "Start to evaluate trained model:"
   -label "A" \
   -thread 40 \
   -trainMode 1 \
-  -verbose true
+  -K 10 \
+  -verbose true \
+  -predictionFile artist_recs

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -308,7 +308,8 @@ void StarSpace::predictOne(
 Metrics StarSpace::evaluateOne(
     const vector<Base>& lhs,
     const vector<Base>& rhs,
-    vector<Predictions>& pred) {
+    vector<Predictions>& pred,
+    bool excludeLHS) {
 
   std::priority_queue<Predictions> heap;
 
@@ -342,9 +343,21 @@ Metrics StarSpace::evaluateOne(
   // get the first K predictions
   int i = 0;
   while (i < args_->K && heap.size() > 0) {
-    pred.push_back(heap.top());
+    Predictions heap_top = heap.top();
     heap.pop();
-    i++;
+
+    bool keep = true;
+    if(excludeLHS) {
+      int nwords = dict_->nwords();
+      auto it = std::find_if( lhs.begin(), lhs.end(),
+                             [&heap_top, &nwords](const Base& el){ return (el.first - nwords + 1) == heap_top.second;} );
+      keep = it == lhs.end();
+    }
+
+    if(keep) {
+      pred.push_back(heap_top);
+      i++;
+    }
   }
 
   Metrics s;
@@ -390,7 +403,7 @@ void StarSpace::evaluate() {
   auto evalThread = [&] (int idx, int start, int end) {
     metrics[idx].clear();
     for (int i = start; i < end; i++) {
-      auto s = evaluateOne(examples[i].LHSTokens, examples[i].RHSTokens, predictions[i]);
+      auto s = evaluateOne(examples[i].LHSTokens, examples[i].RHSTokens, predictions[i], args_->excludeLHS);
       metrics[idx].add(s);
     }
   };

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -347,7 +347,7 @@ Metrics StarSpace::evaluateOne(
     heap.pop();
 
     bool keep = true;
-    if(excludeLHS) {
+    if(excludeLHS && (args_->basedoc.empty())) {
       int nwords = dict_->nwords();
       auto it = std::find_if( lhs.begin(), lhs.end(),
                              [&heap_top, &nwords](const Base& el){ return (el.first - nwords + 1) == heap_top.second;} );

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -64,7 +64,8 @@ class StarSpace {
     Metrics evaluateOne(
         const std::vector<Base>& lhs,
         const std::vector<Base>& rhs,
-        std::vector<Predictions>& pred);
+        std::vector<Predictions>& pred,
+        bool excludeLHS);
 
     std::shared_ptr<Dictionary> dict_;
     std::shared_ptr<DataParser> parser_;

--- a/src/utils/args.cpp
+++ b/src/utils/args.cpp
@@ -56,6 +56,7 @@ Args::Args() {
   saveTempModel = false;
   useWeight = false;
   trainWord = false;
+  excludeLHS = false;
 }
 
 bool Args::isTrue(string arg) {
@@ -185,6 +186,8 @@ void Args::parseArgs(int argc, char** argv) {
       useWeight = isTrue(string(argv[i + 1]));
     } else if (strcmp(argv[i], "-trainWord") == 0) {
       trainWord = isTrue(string(argv[i + 1]));
+    } else if (strcmp(argv[i], "-excludeLHS") == 0) {
+      excludeLHS = isTrue(string(argv[i + 1]));
     } else {
       cerr << "Unknown argument: " << argv[i] << std::endl;
       printHelp();
@@ -277,6 +280,7 @@ void Args::printHelp() {
        << "                   In the case -fileFormat='fastText' and -basedoc is not provided, we compare true label with all other labels in the dictionary.\n"
        << "  -predictionFile  file path for save predictions. If not empty, top K predictions for each example will be saved.\n"
        << "  -K               if -predictionFile is not empty, top K predictions for each example will be saved.\n"
+       << "  -excludeLHS      exclude elements in the LHS from predictions\n"
        <<  "\nThe following arguments are optional:\n"
        << "  -normalizeText   whether to run basic text preprocess for input files [" << normalizeText << "]\n"
        << "  -useWeight       whether input file contains weights [" << useWeight << "]\n"

--- a/src/utils/args.h
+++ b/src/utils/args.h
@@ -61,6 +61,7 @@ class Args {
     bool shareEmb;
     bool useWeight;
     bool trainWord;
+    bool excludeLHS;
 
     void parseArgs(int, char**);
     void printHelp();


### PR DESCRIPTION
As mentioned in Issue #154, the user may want to exclude elements in the LHS from the predictions on the RHS.  The pull adds a CLI flag `-excludeLHS true` to add that functionality.