### PR TITLE
Removing compiler warnings noted in #181

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -101,7 +101,7 @@ void InternDataHandler::convert(
     if (args_->trainMode == 1) {
       // pick one random label as rhs and the rest is lhs
       auto idx = rand() % example.RHSTokens.size();
-      for (int i = 0; i < example.RHSTokens.size(); i++) {
+      for (unsigned int i = 0; i < example.RHSTokens.size(); i++) {
         auto tok = example.RHSTokens[i];
         if (i == idx) {
           rslt.RHSTokens.push_back(tok);
@@ -113,7 +113,7 @@ void InternDataHandler::convert(
     if (args_->trainMode == 2) {
       // pick one random label as lhs and the rest is rhs
       auto idx = rand() % example.RHSTokens.size();
-      for (int i = 0; i < example.RHSTokens.size(); i++) {
+      for (unsigned int i = 0; i < example.RHSTokens.size(); i++) {
         auto tok = example.RHSTokens[i];
         if (i == idx) {
           rslt.LHSTokens.push_back(tok);
@@ -125,7 +125,7 @@ void InternDataHandler::convert(
     if (args_->trainMode == 3) {
       // pick two random labels, one as lhs and the other as rhs
       auto idx = rand() % example.RHSTokens.size();
-      int idx2;
+      unsigned int idx2;
       do {
         idx2 = rand() % example.RHSTokens.size();
       } while (idx2 == idx);
@@ -145,14 +145,14 @@ void InternDataHandler::getWordExamples(
     vector<ParseResults>& rslts) const {
 
   rslts.clear();
-  for (int widx = 0; widx < doc.size(); widx++) {
+  for (int widx = 0; widx < (int)(doc.size()); widx++) {
     ParseResults rslt;
     rslt.LHSTokens.clear();
     rslt.RHSTokens.clear();
     rslt.RHSTokens.push_back(doc[widx]);
-    for (int i = max(widx - args_->ws, 0);
+    for (unsigned int i = max(widx - args_->ws, 0);
          i < min(size_t(widx + args_->ws), doc.size()); i++) {
-      if (i != widx) {
+      if ((int)i != widx) {
         rslt.LHSTokens.push_back(doc[i]);
       }
     }
@@ -218,7 +218,7 @@ void InternDataHandler::getNextKExamples(int K, vector<ParseResults>& c) {
 void InternDataHandler::getRandomWord(vector<Base>& result) {
   result.push_back(word_negatives_[word_iter_]);
   word_iter_++;
-  if (word_iter_ >= word_negatives_.size()) {
+  if (word_iter_ >= (int)word_negatives_.size()) {
     word_iter_ = 0;
   }
 }
@@ -245,9 +245,9 @@ void InternDataHandler::getRandomRHS(vector<Base>& results) const {
   assert(size_ > 0);
   results.clear();
   auto& ex = examples_[rand() % size_];
-  int r = rand() % ex.RHSTokens.size();
+  unsigned int r = rand() % ex.RHSTokens.size();
   if (args_->trainMode == 2) {
-    for (int i = 0; i < ex.RHSTokens.size(); i++) {
+    for (unsigned int i = 0; i < ex.RHSTokens.size(); i++) {
       if (i != r) {
         results.push_back(ex.RHSTokens[i]);
       }

--- a/src/doc_data.cpp
+++ b/src/doc_data.cpp
@@ -133,7 +133,7 @@ void LayerDataHandler::convert(
     if (args_->trainMode == 1) {
       // pick one random rhs as label, the rest becomes lhs features
       auto idx = rand() % example.RHSFeatures.size();
-      for (int i = 0; i < example.RHSFeatures.size(); i++) {
+      for (unsigned int i = 0; i < example.RHSFeatures.size(); i++) {
         if (i == idx) {
           insert(rslt.RHSTokens, example.RHSFeatures[i], args_->dropoutRHS);
         } else {
@@ -144,7 +144,7 @@ void LayerDataHandler::convert(
     if (args_->trainMode == 2) {
       // pick one random rhs as lhs, the rest becomes rhs features
       auto idx = rand() % example.RHSFeatures.size();
-      for (int i = 0; i < example.RHSFeatures.size(); i++) {
+      for (unsigned int i = 0; i < example.RHSFeatures.size(); i++) {
         if (i == idx) {
           insert(rslt.LHSTokens, example.RHSFeatures[i], args_->dropoutLHS);
         } else {
@@ -157,7 +157,7 @@ void LayerDataHandler::convert(
       auto idx = rand() % example.RHSFeatures.size();
       insert(rslt.LHSTokens, example.RHSFeatures[idx], args_->dropoutLHS);
       // pick another random rhs as label
-      int idx2;
+      unsigned int idx2;
       do {
         idx2 = rand() % example.RHSFeatures.size();
       } while (idx == idx2);
@@ -183,12 +183,12 @@ Base LayerDataHandler::genRandomWord() const {
 void LayerDataHandler::getRandomRHS(vector<Base>& result) const {
   assert(size_ > 0);
   auto& ex = examples_[rand() % size_];
-  int r = rand() % ex.RHSFeatures.size();
+  unsigned int r = rand() % ex.RHSFeatures.size();
 
   result.clear();
   if (args_->trainMode == 2) {
     // pick one random, the rest is rhs features
-    for (int i = 0; i < ex.RHSFeatures.size(); i++) {
+    for (unsigned int i = 0; i < ex.RHSFeatures.size(); i++) {
       if (i != r) {
         insert(result, ex.RHSFeatures[i], args_->dropoutRHS);
       }

--- a/src/doc_parser.cpp
+++ b/src/doc_parser.cpp
@@ -43,7 +43,7 @@ bool LayerDataParser::parse(
     start_idx = 1;
   }
 
-  for (int i = start_idx; i < tokens.size(); i++) {
+  for (unsigned int i = start_idx; i < tokens.size(); i++) {
     string t = tokens[i];
     float weight = 1.0;
     if (args_->useWeight) {
@@ -84,7 +84,7 @@ bool LayerDataParser::parse(
     parse(parts[start_idx], rslt.LHSTokens);
     start_idx += 1;
   }
-  for (int i = start_idx; i < parts.size(); i++) {
+  for (unsigned int i = start_idx; i < parts.size(); i++) {
     vector<Base> feats;
     if (parse(parts[i], feats)) {
       rslt.RHSFeatures.push_back(feats);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -108,8 +108,7 @@ void EmbedModel::initModelWeights() {
 }
 
 Real dot(Matrix<Real>::Row a, Matrix<Real>::Row b) {
-  const auto dim = a.size();
-  assert(dim > 0);
+  assert(a.size() > 0);
   assert(a.size() == b.size());
   return ublas::inner_prod(a, b);
 }
@@ -246,7 +245,7 @@ Real EmbedModel::train(shared_ptr<InternDataHandler> data,
     assert(end >= start);
     assert(end <= indices.end());
     bool amMaster = idx == 0;
-    int64_t elapsed;
+    //int64_t elapsed;
     auto t_epoch_start = std::chrono::high_resolution_clock::now();
     losses[idx] = 0.0;
     counts[idx] = 0;
@@ -298,7 +297,7 @@ Real EmbedModel::train(shared_ptr<InternDataHandler> data,
         }
         int etah = eta / 3600;
         int etam = (eta - etah * 3600) / 60;
-        int etas = (eta - etah * 3600 - etam * 60);
+        //int etas = (eta - etah * 3600 - etam * 60);
         int toth = int(tot_spent) / 3600;
         int totm = (tot_spent - toth * 3600) / 60;
         int tots = (tot_spent - toth * 3600 - totm * 60);
@@ -322,7 +321,7 @@ Real EmbedModel::train(shared_ptr<InternDataHandler> data,
   bool doneTraining = false;
   size_t numPerThread = ceil(numSamples / numThreads);
   assert(numPerThread > 0);
-  for (size_t i = 0; i < numThreads; i++) {
+  for (size_t i = 0; i < (size_t)numThreads; i++) {
     auto start = i * numPerThread;
     auto end = (std::min)(start + numPerThread, numSamples);
     assert(end >= start);
@@ -394,7 +393,7 @@ float EmbedModel::trainOne(shared_ptr<InternDataHandler> data,
   check(rhsP);
 
   const auto posSim = similarity(lhs, rhsP);
-  Real negSim = (std::numeric_limits<Real>::min)();
+  //Real negSim = (std::numeric_limits<Real>::min)();
 
   // Some simple helpers to characterize the current triple we're
   // considering.
@@ -418,8 +417,8 @@ float EmbedModel::trainOne(shared_ptr<InternDataHandler> data,
   Matrix<Real> negMean;
   negMean.matrix = zero_matrix<Real>(1, cols);
 
-  for (int i = 0; i < negSearchLimit &&
-                  negs.size() < args_->maxNegSamples; i++) {
+  for (unsigned int i = 0; i < negSearchLimit &&
+                  negs.size() < (unsigned int)(args_->maxNegSamples); i++) {
 
     std::vector<Base> negLabels;
     do {
@@ -558,7 +557,7 @@ float EmbedModel::trainNLL(shared_ptr<InternDataHandler> data,
   }
 
   std::vector<Real> negRate(numClass - 1);
-  for (int i = 0; i < negRate.size(); i++) {
+  for (unsigned int i = 0; i < negRate.size(); i++) {
     negRate[i] = prob[i + 1] * rate0;
   }
 
@@ -696,7 +695,7 @@ void EmbedModel::loadTsvLine(string& line, int lineNum,
     line.resize(line.size() - 1);
   }
   boost::split(pieces, line, boost::is_any_of(sep));
-  if (pieces.size() > cols + 1) {
+  if (pieces.size() > (unsigned int)(cols + 1)) {
     cout << "Hmm, truncating long (" << pieces.size() <<
         ") record at line " << lineNum;
     if (true) {
@@ -707,12 +706,12 @@ void EmbedModel::loadTsvLine(string& line, int lineNum,
     }
     pieces.resize(cols + 1);
   }
-  if (pieces.size() == cols) {
+  if (pieces.size() == (unsigned int)cols) {
     cout << "Missing record at line " << lineNum <<
       "; assuming empty string";
     pieces.insert(pieces.begin(), "");
   }
-  while (pieces.size() < cols + 1) {
+  while (pieces.size() < (unsigned int)(cols + 1)) {
     cout << "Zero-padding short record at line " << lineNum;
     pieces.push_back(zero);
   }
@@ -795,7 +794,7 @@ void EmbedModel::loadTsv(istream& in, const string sep) {
 void EmbedModel::saveTsv(ostream& out, const char sep) const {
   auto dumpOne = [&](shared_ptr<SparseLinear<Real>> emb) {
     auto size =  dict_->nwords() + dict_->nlabels();
-    for (size_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < (size_t)size; i++) {
       // Skip invalid IDs.
       string symbol = dict_->getSymbol(i);
       out << symbol;

--- a/src/model.h
+++ b/src/model.h
@@ -184,8 +184,8 @@ private:
 
   static void check(const boost::numeric::ublas::matrix<Real>& m) {
     if (!debug) return;
-    for (int i = 0; i < m.size1(); i++) {
-      for (int j = 0; j < m.size2(); j++) {
+    for (unsigned int i = 0; i < m.size1(); i++) {
+      for (unsigned int j = 0; j < m.size2(); j++) {
         assert(!std::isnan(m(i, j)));
         assert(!std::isinf(m(i, j)));
       }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -55,7 +55,7 @@ void DataParser::parseForDict(
   chomp(line);
   vector<string> toks;
   boost::split(toks, line, boost::is_any_of(string(sep)));
-  for (int i = 0; i < toks.size(); i++) {
+  for (unsigned int i = 0; i < toks.size(); i++) {
     string token = toks[i];
     if (args_->useWeight) {
       std::size_t pos = toks[i].find(":");
@@ -100,9 +100,9 @@ void DataParser::addNgrams(
     }
   }
 
-  for (int32_t i = 0; i < hashes.size(); i++) {
+  for (int32_t i = 0; i < (int32_t)(hashes.size()); i++) {
     uint64_t h = hashes[i];
-    for (int32_t j = i + 1; j < hashes.size() && j < i + n; j++) {
+    for (int32_t j = i + 1; j < (int32_t)(hashes.size()) && j < i + n; j++) {
       h = h * Dictionary::HASH_C + hashes[j];
       int64_t id = h % args_->bucket;
       line.push_back(make_pair(dict_->nwords() + dict_->nlabels() + id, 1.0));
@@ -179,7 +179,7 @@ bool DataParser::parse(
       continue;
     }
 
-    entry_type type = dict_->getType(wid);
+    //entry_type type = dict_->getType(wid);
     rslts.push_back(make_pair(wid, weight));
   }
 

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -145,7 +145,7 @@ void StarSpace::initFromTsv(const string& filename) {
   vector<string> pieces;
   boost::split(pieces, line, boost::is_any_of("\t "));
   int dim = pieces.size() - 1;
-  if (args_->dim != dim) {
+  if ((int)(args_->dim) != dim) {
     args_->dim = dim;
     cout << "Setting dim from Tsv file to: " << dim << endl;
   }
@@ -231,7 +231,7 @@ Matrix<Real> StarSpace::getDocVector(const string& line, const string& sep) {
 MatrixRow StarSpace::getNgramVector(const string& phrase) {
   vector<string> tokens;
   boost::split(tokens, phrase, boost::is_any_of(string(" ")));
-  if (tokens.size() > args_->ngrams) {
+  if (tokens.size() > (unsigned int)(args_->ngrams)) {
     std::cerr << "Error! Input ngrams size is greater than model ngrams size.\n";
     exit(EXIT_FAILURE);
   }
@@ -303,7 +303,7 @@ void StarSpace::predictOne(
     vector<Predictions>& pred) {
   auto lhsM = model_->projectLHS(input);
   std::priority_queue<Predictions> heap;
-  for (int i = 0; i < baseDocVectors_.size(); i++) {
+  for (unsigned int i = 0; i < baseDocVectors_.size(); i++) {
     auto cur_score = model_->similarity(lhsM, baseDocVectors_[i]);
     heap.push({ cur_score, i });
   }
@@ -333,7 +333,7 @@ Metrics StarSpace::evaluateOne(
   int rank = 1;
   heap.push({ score, 0 });
 
-  for (int i = 0; i < baseDocVectors_.size(); i++) {
+  for (unsigned int i = 0; i < baseDocVectors_.size(); i++) {
     // in the case basedoc labels are not provided, all labels become basedoc,
     // and we skip the correct label for comparison.
     if ((args_->basedoc.empty()) && (i == rhs[0].first - dict_->nwords())) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -105,7 +105,7 @@ void foreach_line(const String& fname,
   using namespace std;
 
   auto filelen = [&](ifstream& f) {
-    auto pos = tellg(f);
+    //auto pos = tellg(f);
     f.seekg(0, ios_base::end);
     return tellg(f);
   };


### PR DESCRIPTION
This is attempt to make compiler messages noted in issue #181 to disappear.
Can you review. 
Especially the commenting out of `Real negSim = (std::numeric_limits<Real>::min)();` in `src/model.cpp`