### PR TITLE
add flag to specify weight separator

### DIFF
--- a/src/doc_parser.cpp
+++ b/src/doc_parser.cpp
@@ -36,7 +36,7 @@ bool LayerDataParser::parse(
   int start_idx = 0;
   float ex_weight = 1.0;
   if (tokens[0].find("__weight__") != std::string::npos) {
-    std::size_t pos = tokens[0].find(":");
+    std::size_t pos = tokens[0].find(args_->weightSep);
     if (pos != std::string::npos) {
         ex_weight = atof(tokens[0].substr(pos + 1).c_str());
     }
@@ -47,7 +47,7 @@ bool LayerDataParser::parse(
     string t = tokens[i];
     float weight = 1.0;
     if (args_->useWeight) {
-      std::size_t pos = tokens[i].find(":");
+      std::size_t pos = tokens[i].find(args_->weightSep);
       if (pos != std::string::npos) {
         t = tokens[i].substr(0, pos);
         weight = atof(tokens[i].substr(pos + 1).c_str());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -58,7 +58,7 @@ void DataParser::parseForDict(
   for (unsigned int i = 0; i < toks.size(); i++) {
     string token = toks[i];
     if (args_->useWeight) {
-      std::size_t pos = toks[i].find(":");
+      std::size_t pos = toks[i].find(args_->weightSep);
       if (pos != std::string::npos) {
         token = toks[i].substr(0, pos);
       }
@@ -116,7 +116,7 @@ bool DataParser::parse(
 
   for (auto &token: tokens) {
     if (token.find("__weight__") != std::string::npos) {
-      std::size_t pos = token.find(":");
+      std::size_t pos = token.find(args_->weightSep);
       if (pos != std::string::npos) {
         rslts.weight = atof(token.substr(pos + 1).c_str());
       }
@@ -125,7 +125,7 @@ bool DataParser::parse(
     string t = token;
     float weight = 1.0;
     if (args_->useWeight) {
-      std::size_t pos = token.find(":");
+      std::size_t pos = token.find(args_->weightSep);
       if (pos != std::string::npos) {
         t = token.substr(0, pos);
         weight = atof(token.substr(pos + 1).c_str());
@@ -164,7 +164,7 @@ bool DataParser::parse(
     auto t = token;
     float weight = 1.0;
     if (args_->useWeight) {
-      std::size_t pos = token.find(":");
+      std::size_t pos = token.find(args_->weightSep);
       if (pos != std::string::npos) {
         t = token.substr(0, pos);
         weight = atof(token.substr(pos + 1).c_str());

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -47,7 +47,7 @@ class StarSpace {
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);
 
-    const std::string kMagic = "STARSPACE-2018-1";
+    const std::string kMagic = "STARSPACE-2018-2";
 
     void loadBaseDocs();
 

--- a/src/utils/args.cpp
+++ b/src/utils/args.cpp
@@ -59,6 +59,7 @@ Args::Args() {
   useWeight = false;
   trainWord = false;
   excludeLHS = false;
+  weightSep = ':';
 }
 
 bool Args::isTrue(string arg) {
@@ -122,6 +123,8 @@ void Args::parseArgs(int argc, char** argv) {
       fileFormat = string(argv[i + 1]);
     } else if (strcmp(argv[i], "-label") == 0) {
       label = string(argv[i + 1]);
+    } else if (strcmp(argv[i], "-weightSep") == 0) {
+      weightSep = argv[i + 1][0];
     } else if (strcmp(argv[i], "-loss") == 0) {
       loss = string(argv[i + 1]);
     } else if (strcmp(argv[i], "-similarity") == 0) {
@@ -293,6 +296,7 @@ void Args::printHelp() {
        <<  "\nThe following arguments are optional:\n"
        << "  -normalizeText   whether to run basic text preprocess for input files [" << normalizeText << "]\n"
        << "  -useWeight       whether input file contains weights [" << useWeight << "]\n"
+       << "  -weightSep       separator for word and weights [" << weightSep << "]\n"
        << "  -verbose         verbosity level [" << verbose << "]\n"
        << "  -debug           whether it's in debug mode [" << debug << "]\n"
        << "  -thread          number of threads [" << thread << "]\n"
@@ -317,6 +321,7 @@ void Args::printArgs() {
        << "minCount: " << minCount << endl
        << "minCountLabel: " << minCountLabel << endl
        << "label: " << label << endl
+       << "label: " << label << endl
        << "ngrams: " << ngrams << endl
        << "bucket: " << bucket << endl
        << "adagrad: " << adagrad << endl
@@ -324,7 +329,9 @@ void Args::printArgs() {
        << "fileFormat: " << fileFormat << endl
        << "normalizeText: " << normalizeText << endl
        << "dropoutLHS: " << dropoutLHS << endl
-       << "dropoutRHS: " << dropoutRHS << endl;
+       << "dropoutRHS: " << dropoutRHS << endl
+       << "useWeight: " << useWeight << endl
+       << "weightSep: " << weightSep << endl;
 }
 
 void Args::save(std::ostream& out) {
@@ -340,6 +347,7 @@ void Args::save(std::ostream& out) {
   out.write((char*) &(trainMode), sizeof(int));
   out.write((char*) &(shareEmb), sizeof(bool));
   out.write((char*) &(useWeight), sizeof(bool));
+  out.write((char*) &(weightSep), sizeof(char));
   size_t size = fileFormat.size();
   out.write((char*) &(size), sizeof(size_t));
   out.write((char*) &(fileFormat[0]), size);
@@ -362,6 +370,7 @@ void Args::load(std::istream& in) {
   in.read((char*) &(trainMode), sizeof(int));
   in.read((char*) &(shareEmb), sizeof(bool));
   in.read((char*) &(useWeight), sizeof(bool));
+  in.read((char*) &(weightSep), sizeof(char));
   size_t size;
   in.read((char*) &(size), sizeof(size_t));
   fileFormat.resize(size);

--- a/src/utils/args.h
+++ b/src/utils/args.h
@@ -29,6 +29,7 @@ class Args {
     std::string loss;
     std::string similarity;
 
+    char weightSep;
     double lr;
     double termLr;
     double norm;


### PR DESCRIPTION
This helps to fix the bug in https://github.com/facebookresearch/StarSpace/issues/191
When` -useWeight `is turned on,  one can use `-weightSep`  to specify the separator for words and weights (default is `':'`). 