### PR TITLE
Fix consistency of README.md input encoding with ImageSpace example

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ With the most recent update, StarSpace can also be used to learn joint embedding
 
 Here we give an example using <a href="https://www.cs.toronto.edu/~kriz/cifar.html">CIFAR-10</a> to illustrate how we train images with other entities (in this example, image class): we train a <a href="https://github.com/facebookresearch/ResNeXt">ResNeXt</a> model on CIFAR-10  which achieves 96.34% accuracy on test dataset, and use the last layer of ResNeXt as the features for each image. We embed 10 image classes together with image features in the same space using StarSpace. For an example image from class 1 with last layer (0.8, 0.5, ..., 1.2), we convert it to the following format:
     
-    d1:0.8  d2:0.5   ...    d1024:1.2   __label__1
+    d0:0.8  d1:0.5   ...    d1023:1.2   __label__1
 
 After converting train and test examples of CIFAR-10 to the above format, we ran <a href="https://github.com/facebookresearch/StarSpace/blob/master/examples/image_feature_example_cifar10.sh">this example script</a>:
 


### PR DESCRIPTION
The current examples/image_feature_example_cifar10.sh example uses an
index starting at 0 (i.e., d0, d1, ...d1023) rather than 1
(i.e., d1, d2, ..., d1024) as indicated in the README.md.
This change changes the README.md to be consistent with the example.