### PR TITLE
Add predictTags and printDocStr for tags prediction

### DIFF
--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -259,6 +259,24 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
   }
 }
 
+unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
+    args_->K = k;
+    vector<Base> query_vec;    
+    parseDoc(line, query_vec, " ");
+
+    vector<Predictions> predictions;
+    predictOne(query_vec, predictions);
+
+    unordered_map<string, float> umap;
+    
+    for (int i = 0; i < predictions.size(); i++) {
+      string tmp = printDocStr(baseDocs_[predictions[i].second]);
+      umap[ tmp ] = predictions[i].first;
+    }
+
+    return umap;
+}
+
 void StarSpace::loadBaseDocs() {
   if (args_->basedoc.empty()) {
     if (args_->fileFormat == "labelDoc") {
@@ -383,6 +401,16 @@ void StarSpace::printDoc(ostream& ofs, const vector<Base>& tokens) {
     }
   }
   ofs << endl;
+}
+
+string StarSpace::printDocStr(const vector<Base>& tokens) {
+  for (auto t : tokens) {
+    if (t.first < dict_->size()) {
+      return dict_->getSymbol(t.first);
+    }
+  }
+
+  return "__label_unk";
 }
 
 void StarSpace::evaluate() {

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -259,6 +259,7 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
   }
 }
 
+//get tag prediction for a text in a hashmap
 unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
     args_->K = k;
     vector<Base> query_vec;
@@ -273,7 +274,7 @@ unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
       string tmp = printDocStr(baseDocs_[predictions[i].second]);
       umap[ tmp ] = predictions[i].first;
     }
-    
+
     return umap;
 }
 

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -261,7 +261,7 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
 
 unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
     args_->K = k;
-    vector<Base> query_vec;    
+    vector<Base> query_vec;
     parseDoc(line, query_vec, " ");
 
     vector<Predictions> predictions;
@@ -273,7 +273,7 @@ unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
       string tmp = printDocStr(baseDocs_[predictions[i].second]);
       umap[ tmp ] = predictions[i].first;
     }
-
+    
     return umap;
 }
 

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -45,7 +45,6 @@ class StarSpace {
     std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
     std::string printDocStr(const std::vector<Base>& tokens);
 
-
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -41,11 +41,17 @@ class StarSpace {
 
     void nearestNeighbor(const std::string& line, int k);
 
+
+    std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
+    std::string printDocStr(const std::vector<Base>& tokens);
+
+
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);
 
     const std::string kMagic = "STARSPACE-2018-2";
+
 
     void loadBaseDocs();
 

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -41,9 +41,8 @@ class StarSpace {
 
     void nearestNeighbor(const std::string& line, int k);
 
-
     std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
-    std::string printDocStr(const std::vector<Base>& tokens);
+    std::string printDocStr(const std::vector<Base>& tokens); 
 
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);


### PR DESCRIPTION
The method predictTags will actually return an unordered_map of k predicted tags given an input text. In a separate PR (coming in a few minutes), I'll add the Python binding and a test case for this new method.