### PR TITLE
Add predictTags and printDocStr for tags prediction

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -48,7 +48,7 @@ sp.initFromSavedModel('tagged_model')
 sp.initFromTsv('tagged_model.tsv')
 
 dict_obj = sp.predictTags('barack obama', 10)
-dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = False )
+dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = True )
 
 for tag, prob in dict_obj:
     print( tag, prob )
@@ -56,15 +56,15 @@ for tag, prob in dict_obj:
 
 And you get this:
 ```
-__label__entitlement 0.36044222116470337
-__label__cspan 0.363872766494751
-__label__notleading 0.42695513367652893
-__label__obamas 0.4439762830734253
-__label__txcot 0.45480018854141235
-__label__txgop 0.4820299744606018
-__label__florida 0.5084939002990723
-__label__doublespeak 0.5218845009803772
-__label__dfw 0.5412008762359619
-__label__obama 0.5869812965393066
+__label__obama 0.5291043519973755
+__label__stopobamasamnesty 0.5073596239089966
+__label__florida 0.5003609657287598
+__label__entitlement 0.47724902629852295
+__label__savesarah 0.4583539664745331
+__label__keystone 0.4561977982521057
+__label__1866 0.43746984004974365
+__label__waroncoal 0.4283019006252289
+__label__notleading 0.4117577075958252
+__label__cuba 0.3887191414833069
 ```
 For the full example, please refer to `test_predictTags.py` in `test` directory.

--- a/python/README.md
+++ b/python/README.md
@@ -13,6 +13,7 @@ nearestNeighbor
 saveModel
 saveModelTsv
 loadBaseDocs
+predictTags
 ```
 #### to be done:
 ```
@@ -38,3 +39,32 @@ chmod +x build.sh
 
 ## How to use?
 API is very easy and straightforward. Please refer `test.py` in `test` directory.
+
+### How to predict tags?
+If you train a model in trainMode=0, you can get tag predictions. Here is the Python code to get prediction for `barack obama` in the political_social_media dataset.
+
+```
+sp.initFromSavedModel('tagged_model')
+sp.initFromTsv('tagged_model.tsv')
+
+dict_obj = sp.predictTags('barack obama', 10)
+dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = False )
+
+for tag, prob in dict_obj:
+    print( tag, prob )
+```
+
+And you get this:
+```
+__label__entitlement 0.36044222116470337
+__label__cspan 0.363872766494751
+__label__notleading 0.42695513367652893
+__label__obamas 0.4439762830734253
+__label__txcot 0.45480018854141235
+__label__txgop 0.4820299744606018
+__label__florida 0.5084939002990723
+__label__doublespeak 0.5218845009803772
+__label__dfw 0.5412008762359619
+__label__obama 0.5869812965393066
+```
+For the full example, please refer to `test_predictTags.py` in `test` directory.

--- a/python/starspace_pybind.cc
+++ b/python/starspace_pybind.cc
@@ -84,10 +84,10 @@ PYBIND11_MODULE(starwrap, m) {
 		.def("getDocVector", &starspace::StarSpace::getDocVector)
 
 		.def("nearestNeighbor", &starspace::StarSpace::nearestNeighbor)
+		.def("predictTags", &starspace::StarSpace::predictTags)
 
 		.def("saveModel", &starspace::StarSpace::saveModel)
 		.def("saveModelTsv", &starspace::StarSpace::saveModelTsv)
-		
 		.def("loadBaseDocs", &starspace::StarSpace::loadBaseDocs)
 		;
 }

--- a/python/test/tagged_post.txt
+++ b/python/test/tagged_post.txt
@@ -1,0 +1,1688 @@
+nowthisnews rep trey radel slams obamacare politics https zvywmg8yih	__label__fl __label__politics __label__obamacare
+video obamacare higher costs broken promises http dn3vzqirwf	__label__obamacare
+senatorleahy 1st step senate debate leahy crapo vawa senateûªs procedural vote today	__label__vawa
+amazon delivery drones need update law promote innovation amp protect privacy uas http l9ta5skq6u	__label__privacy __label__drones __label__innovation __label__uas
+called usdotfra release info inspections casseltonderailment review quality rails	__label__casseltonderailment
+bbcworld help kidnapped nigerian school girls story bringbackourgirls joinrepwilson http zqzvt80mga	__label__joinrepwilson __label__bringbackourgirls
+great pres clinton signing fmla yrs ago today important law protecting workers http csyev7o4 hoyerheadlines	__label__hoyerheadlines __label__fmla
+45pm sen corybooker maiden senate speech need renewui impt issue follow senbookerofc livetweets	__label__renewuisuch
+health coverage starting jan 1st sign accesshealthct end today http fs7mnrppmb getenrolled	__label__getenrolled
+house vote week defundobamacare government open	__label__defundobamacare
+great look idaho native american tribes 1863 idpol idaho150 ktvb http jsxswvpdpv	__label__idpol __label__idaho150
+otd 1969 american astronaut neil armstrong stepped lunar landing module eagle walked surface moon	__label__otd
+agree time actonclimate change info nca2014 released today http sdcnkyudvj	__label__nca2014 __label__actonclimate
+vote working families flexibility act like flexibility choose comp overtime yourtime	__label__yourtime
+reminder week office holding mobile office hours sachse wylie learn http 38p28m2o0i tx32	__label__tx32
+wkûªs min video expanding medicaid help families affordable health care http vdumx9r4x5	__label__wv
+remember friends stuck senatorreid desk 4jobs http 0dcnu1r3g7	__label__4jobs
+american energy production creating jobs holding prices promoting energy independence http pw6cdxrhir	__label__energy __label__jobs
+obamacare spawning new concept medical homelessness http mmupzzkmqj	__label__obamacare
+delaying refusing vote renewui real life consequences million americans http srprczh2dg http fyzwgvwkxz	__label__renewui
+enrolled health site day politico trainwreck http ng4ozr3pab	__label__trainwreck
+job members house representatives voted medicaid expansion yesterday scnews	__label__scnews
+florida tale went right president barack obama health care overhaulû despite gop opposition http bhsacu3wje	__label__florida
+tomorrow amp want makegovernmentwork join problemsolvers showing america fixnotfight	__label__makegovernmentwork __label__fixnotfight __label__problemsolvers
+meeting press jerusalem grahamblog israel http fibhbopswh	__label__jerusalem __label__israel
+video speech house floor rejecting gopbudget cuts jobs turns medicare voucher http titixbrf4c	__label__medicare __label__gopbudget __label__wi
+aaas news basic science riskier investment compared applied research larger potential payoffs oped http	__label__oped
+promising fanniemae paying taxpayers reinforces yrs crash need gsereform help prevent bailout	__label__gsereform
+kxl oil export strategy makes middle man amp worsens climatechange senate shld reject http z8fihvgcko http p4pk9gfw4r	__label__climatechangesenate __label__kxl
+wtvw report mcconnell sponsors sunscreen innovation act playlist http j0yoowhftr kentucky	__label__kentucky
+congrats coleg day session	__label__coleg
+demandarìá obama recuento venezuela creo deberì lee carta tweet whitehouse para decirle piensas http wrhmjlbkzh	__label__venezuela
+icymi spoke wolfblitzer tonight sonyhack amp north korea http prvjk3nb3c	__label__sonyhack
+hosting colorado30 group today hill strengthening connections leaders national defense http wjp0yun2af	__label__colorado30
+looking fwd thirteensoldiers book signing tomorrow changinghands bookstore tempe info http tvuwi3xbuz arizona	__label__tempe __label__thirteensoldiers __label__arizona
+today marks 4th time years pres obama missed legal deadline submit budget plan http rivwkvg1 requireaplan	__label__requireaplan
+joining foxmorningnews roanoke 8am hope tune va06 rke	__label__va06 __label__rke
+dod secy chuck hagel reportedly charge bergdahl exchange claimed know today freebeacon https tlimg8aslt	__label__bergdahl
+clearer lerner irs covering tracks http c2p3nsokp9	__label__irs
+hear recent discussion syria irelandûªs rtenews begins http vkeyereuj4	__label__syria
+tell president obama buck stops http n8t627wxcn irs irsscandal benghazi	__label__irsscandal __label__benghazi __label__irs
+read raise mcdonaldûªs haroldmeyerson washingtonpost http zh4cva5txz strikefastfood	__label__strikefastfood
+househomeland icymi chairman mccaulpressshop cbsthismorning boston bombing investigation yesterday hearing http	__label__boston
+thanks mayornoak willcounty larry walsh joining lewisuniversity airport today good news http txst4jgjel	__label__willcounty
+forget cast vote fl17 congressional art competition winner hang capitol https hrhzbbgi8w sayfie	__label__sayfie __label__fl17
+senate passes vawa reauthorization vote	__label__vawa
+house floor manage rule house gop plan govt open stop obamacare amp protect troops http 7plgqhx4g4	__label__obamacare
+honor amp privilege visit amp thank wyoguard troops stationed bahrain 4th july weekend http rx1rdulmyx	__label__bahrain
+icymi talked mydesert congress work pass strong cir house http 1syj2gev4c	__label__cir
+parents want know kids safe place qualified providers ccdbg essential childcareprotection http wxfvagfe2l	__label__childcareprotection
+utah forced epa lower ozone levels naturally occurring level http ongfkqxokk utahpoliticohub utpol	__label__utpol
+landrieu chance winning incumbent status included http dtcgthynv8 lasen	__label__lasen
+matthewwymt amp michellewymt stopped office earlier talk rxdrugabuse watch wymt 6pm http 28tcnbgfca	__label__rxdrugabuse
+balboa park place usa major cultural institutions mile arts repsusandavis http xggrkdi9iv	__label__arts
+photo joined world interesting man america interesting state landmines event cap hill http 6cvbofvnlu	__label__landmines
+1970 spending grown 288 median income grown difference 264 http g5q55bwi tcot	__label__tcot
+think america succeeds womensucceed http ubqrhikuvg	__label__womensucceed
+joining robbhanrahancbs face state cbs21news morning talk ebola http wcqg6kppf5	__label__ebola
+april sexual assault awareness month according rainn01 sexual assaults reported police standup saam	__label__saam __label__standup
+house gop focused pro growth bills 4jobs itûªs time senatedems act bills ppl work http djssqxyurc	__label__senatedems __label__4jobs
+kerrywashington congrats ellemagazine cover excited girlpower	__label__girlpower
+sfrc hearing today secretary kerry watch live http ay1kz8x97x	__label__sfrc
+time obama admin answer american people benghazi americans murdered held accountable	__label__benghazi
+rep wilson commemorates anniversary earthquake action remember haiti http 05vbzrdw	__label__haiti
+vets groups editorials democrats agree funding äê vaaccountability http 9i3lxjxzac	__label__vaaccountability
+year senate passed comprehensive immigration reform timeisnow house act http sesuk4jjwg	__label__timeisnow
+uani vote counts iranelection today unelected supreme leader http a3acacqqrh	__label__iranelection
+madeinwi economy cooking good check madisoncollege new culinary training center http 19lrccwwpp	__label__madeinwi
+faces hunger veterans children seniors disabled gopleader cut snap endhungernow http zvimyzi1kc	__label__snap __label__endhungernow
+delco county council chairman tom mcgarrigle declared weather related state emergency	__label__delco __label__weatherrelated
+thanks onecampaign visiting paul staff amp great work fighting global poverty amp hunger http xcsocfoewc	__label__poverty __label__hunger
+proddenergy thing oil amp wind compete stabenow said morning wind needs catch	__label__proddenergy
+continue working strong bipartisan comprehensive immigrationreform plan including dreamact support groups like ct4adream	__label__dreamact __label__immigrationreform
+need effective ways address addiction crisis people like griffins know help	__label__addiction
+deltadiva3 idea allow students pay rate govt loans big banks currently askdems	__label__askdems
+ryanbudget hurts country comes medicare hurts seniors program seniors future	__label__ryanbudget
+great senator richard bryan homemeansnevada battleborn http ksbvjcadny	__label__battleborn __label__homemeansnevada
+antiochpolice 47th neighborhood cleanup working antioch amp ca9 clean http oxzgmnicjl	__label__antioch __label__ca9
+obama talked abt infrastructure projects heard firsthand account delay keystone negatively impacted business time2build	__label__time2build __label__keystone
+letûªs thank veterans service sacrifice ceremony parade picnic tue nov 11am http mqhlr1wzey	__label__veterans
+admin reached deal man bragged advancing nukes prgrm deception remain skeptical nkorea	__label__nkorea __label__nukes
+breaking silence irs outrage http bx27adwu2o newyorkobserver irstargeting	__label__irstargeting
+going talking golfchannel memorialtournament efforts congressional gold med goldenbear jack nicklaus	__label__memorialtournament __label__goldenbear
+washingtonpost transcript president obama speech http d6i5rt1wpd marchonwashington mow50	__label__marchonwashington __label__mow50
+yubasutterarts know student wants art displayed capitol http reyuuvxuix	__label__art
+today house voted favor national flood insurance fund protects 1300 isaac claim payments delayed	__label__isaac
+apropiado maduro ortega juntos nicaragua ambos manipuladores elecciones venezuela nicaragua necesitan elecciones libres	__label__nicaragua __label__venezuela
+great labor day weekend indy safe travels family hope district	__label__indy
+job pass laws favors foreign oil corporations keystone http bnhvondflz	__label__keystone
+thanks algore making time speak eedayri icymi video speech http h5ogi3gj9a	__label__eedayri
+tbt president fdr signed socialsecurity act law otd 1935 itûªs preserve amp protect http b2yybxs3ug	__label__tbt __label__otd __label__socialsecurity
+gopshutdown mean sbagov stop processing loans american smallbusinesses enoughalready	__label__gopshutdown __label__enoughalready __label__smallbusinesses
+ncfarmbureau farmbill 2013 voted senate committee yesterday house committee schedule vote version tonight	__label__farmbill
+official claims clinton allies scrubbed benghazi docs secret sessions http g7xyhdvm0g	__label__benghazi
+headed whitehouse signing bipartisan worker training modernize workforce development wioa	__label__wioa
+tune sec kerry testifying syria hascrepublicans watch http 5zzhknjco2	__label__syria
+gop proposal sets cap rates amp cost students thousands extra dollars dontdoublemyrate http miiqmrq1uj	__label__dontdoublemyrate
+congrats southwestair yrs ago 1st flights dallaslovefield luv having serve tx27 ccintairport amp austinairport	__label__tx27
+cnn ûïdemocratic senator asks obama delay obamacare deadlineû http tvbzbsau99 fairnessforall	__label__obamacare __label__fairnessforall
+join senwarren mayortommenino amp rep capuano faneuil hall boston today 11am demandaction nomorenames http q5ulw6lgm4	__label__demandaction __label__boston
+todayûªs supreme court action continues march progress marriageequality http l41phswcfy 26statestogo	__label__marriageequality __label__26statestogo
+clip speaking gop leadership press conference morning fairnessforall http b6xs8mji8u	__label__fairnessforall
+plsd cdcgov report showing childhood obesity falling states incl http qnopven5c2 cont	__label__ny
+read letter potus reforming lay vision mending clearly broken http ex5z6szspr	__label__va
+nrecaintl thx senmarkpryor recognizng volunteers recent work guatemala highleyunlikely melfly1 coopsindc http tû	__label__coopsindc
+laborday picnic eriecounty penny amp visiting waterford fair	__label__waterford __label__laborday __label__eriecounty
+ghostreconlee proud cosponsor 3546 extend critical lifeline year renewui http 8uey04moei	__label__renewui
+replindasanchez housegop shouldn limit access quality earlyed instead invest future http mfh6njmicd	__label__earlyed
+said nbc6 airstrikes long overdue support action obama shouldn circumvent congress https tyqzlguwns	__label__congress __label__obama
+itûªs support 1010 raisethewage hour timefor1010	__label__raisethewage __label__timefor1010
+false lewis amp clark encountered grizzly bears northdakota nationaltriviaday	__label__nationaltriviaday __label__northdakota
+great times yalcon13 yaliberty http cjssicvk4b	__label__yalcon13
+obama took office lost 592 000 manufacturing jobs http q7vtz1y7fk speechesdonthire	__label__speechesdonthire
+honor sakia gunnûªs memory letûªs real action lgbtq equality amp violence discrimination aaogcnewark http 5svbu2siuk	__label__equality
+introduced growth act today dentpressshop reform unemployment insurance bolstering job creation http x0tc8ssjtj	__label__unemployment
+aca requires insurers spend premiums medical care result americans got rebate getcovered http jdphg4ev3g	__label__getcovered
+larry webb city rio rancho says conservation big deal low hanging fruit comes water alternatives nmwaterinnovation	__label__nmwaterinnovation
+inspired effort navy osu today proud midshipmen gonavy	__label__osu __label__navy __label__gonavy
+theyûªll longer aca ûïchicago area hospitals crain list longest waits û crainschicago http 5diwaykniq	__label__aca
+americasvoice working left wing playbook agree version immigrationreform want hater	__label__immigrationreform
+great lunch hotel congress tucson great historic hotels arizona http z6uiyifx	__label__arizona __label__tucson
+believe america work hard amp play rules able ahead paycheckfairness http vl8rimfixa	__label__paycheckfairness
+happy birthday flotus michelle obama youûªve fantastic lady wonderful leader veterans issues andmanymore	__label__andmanymore
+cosponsoring senatorshaheen robportman increase energyefficiency public amp private sectors http vagyn98pz7	__label__energyefficiency
+veterans federal govtûªs online benefits experience glitches sound familiar http s8eb7ske12	__label__glitches
+today let celebrate freedoms blessed live great country happy independenceday http jxwnvpsbhw	__label__independenceday
+years hezbollah backers iran aim attack national security interests	__label__hezbollah __label__iran
+creative coenergy development edf heartland biogas proj weldcounty shows driver seat innovation http 1prtjvqjxv	__label__weldcounty __label__biogas __label__co __label__coenergy
+medicare open enrollment underway hereûªs house save program bluebagnews http xewjrqzkny oh08	__label__oh08
+looking forward having gabbygiffords guest sotu tonight great house	__label__sotu
+thanks sharing pjnet video new pjnet video showcase entry courtesy house member repfinchertn08 http c6nmpio6nj	__label__pjnet
+ianhainline foreign born grad grad degree univ stays amp works stem creates avg jobs imarch	__label__stem __label__imarch
+talked abt impt local nat issues univision airs 2nite 30pm miami http 2kz2la0e	__label__miami
+great lincoln electric proud successful company headquartered ohio oh14	__label__oh14
+standing furloughed fed workers rain want congress jobs theirs gopshutdown http 7a4z8uvxly	__label__gopshutdown
+senatedems 270 000 veterans benefit house took passed senate renewui http hmt45ghsym	__label__renewui
+cbo confirms knew obamacare destroy millions time jobs law trainwreck http uilm89yopr	__label__obamacare __label__trainwreck __label__jobs
+congrats congressional art competition winners ca43 christopher lizama adrian sanchez soohyun park amp adilah trimble	__label__ca43
+2million americans lost needed unemployment insurance time renewui	__label__renewui __label__2million
+urge senate reauthorize vawa allow inaction undermine rights women	__label__vawa __label__senate
+massive turnout expected pelican state voter billcassidy today votecassidy http esvokqnd84	__label__votecassidy
+urge vote gopbudget recipe economic decline amp immediate job loss rewards millionaires expense	__label__gopbudget
+tigernbham house demsûª makeitinamerica plan focused bringing jobs incl tax incentives encourage invstmnt askdems	__label__askdems __label__makeitinamerica
+obama amp senate dems obamacare break big biz stiffing hardworking americans fairnessforall http afhbnrrhnd	__label__obamacare __label__fairnessforall
+bctimes shalegas agreement btwn consol energy amp pitairport lead dev 500m new revenue read http wcmq1pdylp	__label__shalegas
+swetalk pres stacey delvecchio joined stem caucus panel discuss improving stem amp workforce diversity http tpuaol4gwh	__label__stem __label__il
+talked foxnews teamcavuto obamacare subsidies congress act video http 8bvyq0bubf nosubsidies4congress	__label__nosubsidies4congress
+watch joint hearing repchrissmith citizen pastor freesaeed imprisoned iran christian faith http uqsfgrnxry	__label__freesaeed __label__iran __label__christian
+gave floor speech today highlighting ûï150 reasons love west virginia û watch http 0pnu26fxdb 150reasons	__label__150reasons __label__wv
+moving conference budget best signals congress send america watch http xot3arpt3t mepolitics	__label__budget __label__mepolitics
+placer reunirme directora ntn24 cgurisattintn24 discutir venezuela debemos apoyar lucha libertad http iyim1p7fbe	__label__libertad __label__venezuela
+ridiculous peenymcneeny repjeffduncan traitors complain taxes pjnet	__label__pjnet
+icymi link pilotnews expand medicaid program http ygezggpnz7 obamacare	__label__va __label__obamacare __label__medicaid
+house voted defund obamacare government open senatemustact http d3mvmagbwi tx25	__label__obamacare __label__senatemustact __label__tx25
+help companies start grow produce amp sell products world support renewing eximbankus exim4jobs	__label__exim4jobs
+sanders cut social security disabled veteransûª benefits http hdcn0tspql veterans chainedcpi	__label__veterans __label__chainedcpi
+stewsays senate voting sen mikecrapo amendment budget	__label__budget __label__senate
+change work today add incredible progress lifetimes passenda http ojao5zz28u	__label__passenda
+great news ûò supreme court upheld marriage equality love law http 5hkpv3ivpd gaymarriageor	__label__gaymarriageor
+want know senators voted block equalpay åêhttp ve8qyfteqy	__label__equalpay
+ufwf ufwupdates house hearing thank rep luisgutierrez amp repzoelofgren support farmworkers http 3dkujû	__label__farmworkers
+amtrakcareers yes repjeffdenham think dog support petsontrains happy nationaldogday amtrak k9s http	__label__petsontrains __label__amtrak __label__nationaldogday
+repfredupton brokenpromises routine delays dramatically higher healthcare premiumsû exactly abetterbargain	__label__abetterbargain __label__brokenpromises
+taxinversions symptoms deeper problem let fix entire taxcode video http jefiadmjuf	__label__taxcode __label__taxinversions
+white house finally admits true americans won able health care plan obamacare morebrokenpromises	__label__morebrokenpromises
+pres obamaûªs interior secretary salazar fracking environmental problem http jczkdikdnv	__label__fracking
+thanks sharing great independenceday ûï adamslane17 repstevestivers watching musical 1776û	__label__independenceday __label__musical
+thinks proposed internet ûïfast laneû rules ûïdiscriminatory amp anticompetitive learn http jon6kvkouz netneutrality	__label__netneutrality
+foreignrelations brettonwoodscom donûªt believe peace til nudge leaders work betterment	__label__foreignrelations
+sen stabenow leading fight student loan rates low join dontdoublemyrate http btskg85gy0	__label__dontdoublemyrate
+msnbc tuesday 10amet 10ampst doubling broadcast northkorea lets kim jong double dose free speech	__label__northkorea
+happy easter celebrating today wishing amp families joyous holiday day peace amp renewal	__label__easter
+crainschicago governorquinn itûªs official marriageequality law land illinois http xuh7qhlqdy http	__label__marriageequality
+met manufacturing extension partnership today discuss importance manufacturing economy http cedq2mp32l	__label__nh
+financialcmte doddfrank years later http uuzxsz248r	__label__doddfrank
+tune loudobbsnews discuss border crisis amp visit mcallen investigate problems hand	__label__border
+obamacare customers blindsided expensive taxes irs http ttepgnloaj	__label__obamacare
+payday dublin got covered peanut payday world roasted dublin http vfaigkhmso	__label__payday
+congressfdn 7th golden mouse award proud use tech democracy open amp accessible http jm9vbfzait	__label__tech __label__democracy
+reminder rsvp fri aviation field hearing faa tech center focus nextgen uas role safety http r0q3iq6f59	__label__aviation
+house passed permanent internet tax freedom act week senate needs act tcot nointernettax http 0kljrw1hz8	__label__nointernettax __label__tcot
+joined repraulgrijalva intro protect cte funding nevada cte critical economic recovery http ukaeq4a7fa nv03	__label__nv03 __label__nevada __label__cte
+myth raising wage liberal issue true ûïvoters red blue states consistently supported itû new jersey 2013	__label__2
+middle amp low income families hurt carbontax need approach americanenergy	__label__carbontax __label__americanenergy
+itûªs time reject status quo offer parents choice schools best fit needs kids schoolchoice	__label__schoolchoice
+studying climate amp socioeconomic patterns caused trade inland cities coastal cities central america chicagoclimate	__label__chicagoclimate
+ignoring law way think difficult defend legally president obama executiveamnesty	__label__executiveamnesty
+marcorubio superbowlxlviii winner denverbroncos happy superbowlsunday	__label__superbowlxlviii __label__denverbroncos __label__superbowlsunday
+nolabelsorg days problemsolvers big announcement july ready fixnotfight	__label__fixnotfight __label__problemsolvers
+today national day prayer hope join today lifting great nation prayer	__label__prayer
+share think texas expandmedicaidnow http oxl7kxccx4	__label__expandmedicaidnow
+fox5sandiego talk studentloanrates nsa immigrationreform amp bipartisanship https on60quupbh dropthatdebt	__label__immigrationreform __label__studentloanrates __label__nsa __label__dropthatdebt __label__bipartisanship
+wrrda strong bipartisan jobs long overdue http vdoeqzrm2a	__label__wrrda __label__jobs
+continue work parties solution reached future job losses prevented noranda	__label__noranda
+check huffpostpol blog post time clear air real cost flying realairfares http n5cocyxa53	__label__realairfares
+noh8onthehill washingtonpost proud help great event http 5nywyqoivz	__label__noh8onthehill
+newsmaxtv theforum nmx thanks having morning discuss isis threat	__label__isis
+story hope faith goodness people aldotcom courage prayer duckdynasty cast fairhope http p1p14jaunt	__label__duckdynasty
+tradition continues today memorialday come remember sacrificed lives defense freedoms	__label__memorialday
+breaking griffin calls exxon relocate pipeline http j9okimyln7 ar2	__label__ar2
+celebrating chinese new year summerlin lions club lions world largest service organization gung hay fat choy nv03	__label__nv03
+nihdirector strong words support biomedical research eric cantor milken global conference 2013gc nih	__label__nih __label__2013gc
+senateapprops chairwoman senatorbarb emphasize need nasa economic engine fy14 budget hearing live 30am httû	__label__budget __label__economic
+scarborough beach launching ûïsun smartsû public health campaign prevent skincancer rihospital rihealth pawsox amp dermatologists	__label__skincancer
+houseagnews mark 2013farmbill tomorrow rice critical economy ar01 http ykrdyrlsoi	__label__2013farmbill __label__rice __label__ar01
+partner trademeansjobs repboustany tpa4usjobs priority congress uschamber chamberglobal	__label__tpa4usjobs
+remieconomics fred treyz discusses remi report shows state state cirmeansjobs http ktrcapbirf	__label__cirmeansjobs
+eric holder won appoint special prosecutor investigate irs scandal impeached http blwxxumcgx	__label__irs
+surgeongeneral post critical public health vacant 2013 vivek murthy deserves confirmed topdocnow	__label__surgeongeneral __label__topdocnow
+fbi director hasan inspired qaida tx25 forthood http y2sstbai7k	__label__forthood __label__tx25
+telemundonews congresista ileana roslehtinen explica por quì© reformamigratoria podrì verse afectada por crisis siria	__label__ __label__siria __label__reformamigratoria
+nsf research strengthen people amp help smarter decisions watch stand4science ncpol http h7ajdbk42j	__label__ncpol __label__stand4science
+harvey milk spoke wouldnûªt feel compelled live silence equality harveymilkstamp	__label__equality __label__harveymilkstamp
+great visit kmart pharmacy mentor ohio morning learn work oh14 http get8chqrwo	__label__oh14
+karen mandatory evacuation currently place grand isle louisiana	__label__karen __label__louisiana
+example transparent administration history right hiding fastandfurious http zovhzlxckt	__label__fastandfurious
+93wibc news rokita calls surveillance court declassify rulings http i2mwqtcpiq fisa	__label__fisa
+2012 sotu ûïi want cut maze confusing training programs û housegop passed skillsact tell senate pass	__label__skillsact __label__sotu
+pleased mahoning juvenile court taking proper steps address mentalhealth http dxfm8edldm vindicator	__label__mentalhealth
+thanks joined weekûªs momornings learn attend http 4jzmfonfrz	__label__momornings
+watch press conference introducing chiff children families act http wqvltngibb learn http 2np4qllpdc	__label__chiff
+hfacdemocrats 1st episode askengel metodijakoloski amp therealmrtim ask support nato enlargement amp syria htû	__label__askengel __label__syria
+message american people let washington way use yourtime watch amp http vddilviifz	__label__yourtime
+esea works partnership states overhaul nclb improve schools boosting opportunities amp access students	__label__esea __label__nclb
+happy participating 2013 coffeewithcongress series hosted smartnonprofits amp unitedwaytc http wlsu6x7v3y	__label__coffeewithcongress
+bernade87545622 fwd thanks speaking agree timeisnow immigration reform http fatsvirqq7	__label__timeisnow __label__immigration
+victory taste sweet ask stillmankbeer won bronze gabf madeinwi bitter brew wisco disco	__label__madeinwi
+join tonight haltom city townhall meeting http 1lcndakktv	__label__townhall
+let huskies uconn	__label__uconn
+statement monday bpoilspill lake michigan http s8fbenoadw	__label__bpoilspill
+obamacare proof need readthebills law citizen sponsor today https kwqnomndsp	__label__readthebills __label__obamacare
+nsa control http t8ghsmxxk6 nsa nsaspeech	__label__nsa __label__nsaspeech
+watching irs hearings week makes think irs good candidate mike rowe dirty jobs bsirs irsscandal	__label__irsscandal __label__bsirs
+omw leadership press conf actions congress sure fairshot watch http mhtf6budww	__label__fairshot
+think american people deserve know true cost government http 7qtbzhb8ez nofreelunch budget tcot	__label__nofreelunch __label__tcot __label__budget
+wife erika hospital birth kids throwbackthursday tbt http 87htiyqnku	__label__tbt __label__throwbackthursday
+vietnam war memorial ceremony brazos valley veterans park usa rememberourvets http 91etjukz7c	__label__usa __label__rememberourvets
+looking like washington irs misconduct http a768oks1mi halththeirs teaparty	__label__halththeirs __label__irs __label__teaparty
+good morning minnesota polls open 7am text govote amp address zip 97779 polling place	__label__mn
+america allow boss decide employee sexually assaulted military passmjia	__label__passmjia
+spoke protecting fishing families access sofl greatest treasures biscaynenps http j3vsktffeg	__label__sofls
+link washingtonpost witnify video interview sen leahy recollections jfk assassination http 9n0klt1atk	__label__witnify __label__jfk
+taking questions live tele townhall wednesday night click link sign idpol http puoeqyblj8	__label__idpol
+safe happy patrick day weekend indy	__label__indy
+ambassadororen ambshapiro jerusalem mayor nir barkat repeliotengel obamainisrael speech today http mpa33xipp3	__label__jerusalem __label__obamainisrael
+nation adventurous spirit dark days pain loss years ago challenger http c2vc9c3u	__label__challenger
+senrandpaul follow friend ally repthomasmassie ûò true voice fight liberty amp const gvt agree tcot thx	__label__tcot
+president instructed agencies sequestration painful possible best america	__label__sequestration
+tune wjrradio paulwjr hear oscars2014 recap discuss ukraine suspending participation summit	__label__ukraine __label__oscars2014
+raisethewage behalf million restaurant workers work tips	__label__raisethewage
+ultimate solution repeal word obamacare callwithcruz	__label__callwithcruz
+marketplacefairness act help level playing field retailers help states collect taxes owed http wfhokchwk1	__label__marketplacefairness
+happy 4th july il05 lincoln words lasting reminder freedom america independenceday http cnq4xj6edw	__label__independenceday __label__freedom __label__il05
+claire bipartisan effort aimed getting nature problem campus sexual assault 1is2many http ssbtxpj5oy	__label__1is2many
+billion lost econ activity days shutdown forward issues stalled long	__label__shutdown
+solution irs targeting conservatives eliminating irs repeal16 http dau5myejoo	__label__repeal16 __label__irs
+million hardworking americans district benefit raisethewage look http bvuazwn7rc	__label__raisethewage
+ksvr 3604167000 cal	__label__ksvr
+breaking non partisan cbo reports obamacare cost nation million jobs amp trillion new debt http snrybhfycl	__label__obamacare
+congrats winners miamidadecounty friendslibrary teen photography contest blackhistorymonth http k2lquvnjc4	__label__blackhistorymonth
+kicking actsofkindness reading kids ywca new britain honorwithaction http wkrq3zko2a	__label__honorwithaction __label__actsofkindness
+5yrs ago transcanada submitted application statedept keystonexl timetobuild jobs amp advance energysecurity usa	__label__timetobuild __label__energysecurity __label__keystonexl __label__jobs
+opportunityplan equal pay paid family leave raise minimum wage affordable child care pre http 28irbmiej3	__label__opportunityplan
+chronic diseases left access vital medicines obamacare http czgohkdki2	__label__obamacare
+cbseveningnews qaeda affiliate organizing helping amp participating completely inaccurate benghazi	__label__benghazi
+house passed numerous bills empower students affordable education possibility stuckinthesenate http tgqtiotnzt	__label__stuckinthesenate
+forget gun control new mentalhealth plan stop mass shootings http 3kwnx0h7yo jfkucinich amp posttv hr3717	__label__hr3717 __label__mentalhealth
+barackobama truly worried faith amp credit control debt sotu randresponds	__label__randresponds __label__sotu
+president support jobs energy independence approving keystonexl sotu	__label__energy __label__keystonexl __label__sotu __label__jobs
+weûªll reward schools develop new partnerships colleges classes focus science technology engineering math stem	__label__stem
+briefbrady townhalls week hope tomball http mnmdejovuh montgomery http nba3cvhgob	__label__briefbrady
+welcome secretary kerry look forward working issues confronting western hemisphere hfacrepublicans az05	__label__az05 __label__kerry __label__az
+speakerboehner learn gabriella miller kidsfirst research act visit http edbhaizqs4	__label__kidsfirst
+obamacare effect widening income gap http il7mk3ilep	__label__obamacare
+tune cnnsitroom wolf blitzer today 5pm discussing waronpoverty50th anniversary	__label__waronpoverty50th
+lowellfolkfest weekend great music fun food world lowellfolk http xtwyijxn4m	__label__lowellfolk
+like facebook page updates working hard http rgunevfkq2	__label__nm
+exhilarating chrysler 200 unveiling naias car built plant shuttered years ago	__label__naias
+great article peoplesworld mlkday seattle spoke raising min wage reducing incomeinequality http uabixn9jla	__label__incomeinequality __label__mlkday __label__seattle
+azpm uofa program provides insured people insurance free eye screenings tucson health https 5nsztz3lws	__label__health __label__tucson
+medicare matters keeps southern arizona seniors healthy	__label__medicare
+21m headstart grant caoeriecounty foster lifelong appreciation learning improve opportunity youth http klezhmv0ke	__label__headstart
+week chair smallbizgop subcommittee hearing challenges facing smallbiz owned service disabled veterans ny22 4jobs	__label__4jobs __label__smallbiz __label__ny22
+hearing tonightûªs sotu address pivot jobs lost focus jobs nationaljournal http ixu4y77x	__label__jobs __label__sotu
+bipartisan support ecpa needs updated digital age protect online communications emailprivacyact	__label__emailprivacyact __label__ecpa
+hughhewitt going live tune speakerboehner marksteynonline amp james lileks http yaya9ekk3c hewitt	__label__hewitt
+nra powerful people power powerful exercise	__label__nra
+managing debate funding national parks museums closed gopshutdown	__label__gopshutdown
+rep cantor district support bipartisan immigration reform awaiting house consideration http szrnwit1sz timeisnow	__label__timeisnow
+started housevetaffairs committee hearing vascandal watch live http jmwibwuzso span	__label__vascandal
+proud help launch womensucceed economic agenda support millions women working achieve job security amp stability	__label__womensucceed
+week stopped briafcliffmanor department thank critical public service	__label__briafcliffmanor
+tune foxbusiness discussing week irs hearing	__label__irs
+icymi rep larry bucshon hosting live facebook chat driverless vehicles theheraldtimes amp govtracker http vg6fzvqlgo	__label__driverless
+thx repgutierrez amp repjoseserrano champs immigrantreform join community efforts http wqmiwpko3q	__label__immigrantreform
+veterans new online resource connect employers jobs opportunity ûò share https ix7d3afcnf	__label__opportunity __label__jobs
+know sochi site upcoming winter olympics amp longbeach sister cities http sykwxr2g9v sochi2014 goteamusa	__label__sochi __label__sochi2014 __label__goteamusa __label__longbeach
+saving women lives obamacareinthreewords	__label__obamacareinthreewords
+lonnie shea research team share work cancer biology regenerative medicine path2cures http b5es8qvuva	__label__path2cures
+clancycnn chibokgirls waiting bringbackourgirls today joinrepwilson	__label__joinrepwilson __label__bringbackourgirls __label__chibokgirls
+letsgooakland	__label__letsgooakland
+sexton act integrate mental health assessments soldierûªs annual pha improving existing milhealth	__label__milhealth
+great visiting coastal coffee roasters summerville smallbusinesssaturday whoyagonnacall http mbv8odiyck	__label__whoyagonnacall __label__smallbusinesssaturday
+need strategic plan stop spread isis hateful ideology violence hjres123 isis	__label__hjres123 __label__isiss __label__isis
+minutes house vote defund obamacare avoid government shut senatemustact	__label__senatemustact
+wishing happy birthday makeitinamerica champion friend illinois replipinski	__label__makeitinamerica
+obamacare website faces security risks watchdog finds http wh3ec84300 wsjhealth	__label__obamacare
+join stevemtalk 20pm discuss president waroncoal tune http upvxsiiytv	__label__waroncoal
+proud cosponsor emailprivacyact learn strengthen 4th amdt http g3l2lapiud	__label__emailprivacyact
+great day religiousfreedom scotus sides hobbylobby case aca contraception mandate istandwithhobbylobby	__label__hobbylobby __label__religiousfreedom __label__istandwithhobbylobby __label__scotus
+tax tips newsletter http b0jw2ptvse future updates like sure subscribe newsletter	__label__tax
+house transportûªs review morganzatothegulf today long overdue welcomed step including final water resources	__label__morganzatothegulf
+leecruse thanks having sen mcconnell wvlk today discuss hemp seeds held dea kentucky	__label__kentucky
+pueblochieftain immigration congress historic opportunity useful http zqox6fjo5w	__label__immigration
+ableact levels playing field disabilities letûªs law land http 7tkp4g6xpp	__label__ableact
+talking winner congressional art competition tx23 3tx23 http ezqgqhgxnb	__label__tx23
+happy 90th jack davis madison celebrating today guilford wonderful family community grateful boundless service	__label__madison __label__guilford
+epwrepublicans receive answers requests video ginamccarthy press conference http 4sjchpu7l8	__label__ginamccarthy
+repjimmcdermott gop committed job growth meaningless gestures obamacare 37x http lx3kjvzû	__label__obamacare __label__gop __label__37x
+like darrellissa ask irs commissioner tonight share https 7uyph1zzoh tcot	__label__tcot __label__irs
+hope time read senator judd greggûªs obamacare thehill idpol http xou8hic9i7	__label__obamacare __label__idpol
+believe cancer survivor health care isn simple republicans tell obamacare stories black white http aq18scqhcz	__label__obamacare
+ûïmil needs environment victims come fwd fear retaliationû quote repmiketurner dod mst report http 2dcpjqpm4x	__label__mst
+replynnjenkins good piece repmikepompeo usatoday president health care law trainwreck http bcihyl6ukd	__label__trainwreck
+john brennan cases unauthorized interrogation techniques ûïwere abhorrent rightly repudiated û readthereport	__label__readthereport
+answered beckylockhart ice bucket challenge fight cancer https afvsk5nnft challenge mayorbenmcadams utpol	__label__utpol
+video foxnews senator ayotte says obamacare problems website http h2kyockdiz	__label__obamacare
+thank ryanoferguson congrats repjoekennedy manufacturing act signed pres obama good good mapoli	__label__mapoli
+proud honor vietnam vet thomas doody amp long overdue presidential unit citation brother jim http 9ahlj1tlm6	__label__vietnam __label__vet
+stockman seeks protect workers labor unionûªs coercive û÷card checkûª http umjtjndzes pjnet	__label__pjnet
+colsgachamber happy announce membership congressional defense communities caucus veterans	__label__veterans
+live http poy0jeqqmz remembering 1989 tiananmen square massacre leader pelosi amp repchrissmith	__label__tiananmen
+benaffleck moment read powerful easterncongo board member cindymccain recent trip congo http	__label__congo
+think obamacare bad step http 45zvqspt1a stop dontfundit defundobamacare	__label__defundobamacare __label__dontfundit
+hey md02 need help office coming visit facebook page information help https hjdtabwtaq	__label__md02
+attention nv03 hosting job fair career skills workshop oct employers looking hire visit http l6xkd3zcwq info	__label__nv03
+great roundtable gunviolence today mayors mothers police came discuss solutions http vohnkou7km	__label__gunviolence __label__ri
+cosponsoring real nobudgetnopay actually encourages house amp senate job http lzq4bbvf	__label__nobudgetnopay
+thoughts amp prayers families oklahoma affected tornadoes blessed strength amp courage face tragedy netde	__label__netde __label__oklahoma
+harry reid president accept responsible compromise government open http rct8macv76 az05	__label__az05
+column today theobserver opportunity presented interim nuclear agreement iran ncpol http yztaoiubpy	__label__ncpol
+repduckworth blasts witness claiming veterans disability gain gov contracts http d4neaa8poa irs	__label__irs
+arlington eagles win state fastpitch championship oftheworld great job eagles northsnohomish heraldnetsports	__label__oftheworld
+submit questions rep wolf hashtag cspanwj cspanwj 202 585 3881 republicans 202 585 3880 democrats	__label__cspanwj
+obamacare unpopular read http jkhuakfklv la03	__label__obamacare __label__la03
+bipartisan work amp cooperation passed fixflood insurance rates folks http s6vaaqfcts	__label__fixflood
+kellogg woman husband farm concerned qualifying disaster assistance grass suffered drought klinetth	__label__klinetth
+obamacare working way supposed http x0uq3ov4lb trainwreck	__label__obamacare __label__trainwreck
+congrats berkeleyûªs alicewaters named time magazineûªs 100 influential people time100	__label__berkeleys __label__time100
+conservative icons ronald reagan amp justice scalia recognized need commonsense protections gun violence nowisthetime	__label__nowisthetime
+good morning tx25 looking forward busy day ahead today house continue debate homeland appropriations	__label__tx25
+enjoyed opportunity visit uinations students yesterday glad got committee hearing idpol http qyfzxhmlir	__label__idpol
+murray sacrifice come form unwanted sexual contact ranks combatmsa	__label__combatmsa
+thx happy thanksgiving barbrhondi repdonaldpayne thanksgiving grateful4gunsense shown thx momsdemandaction	__label__thanksgiving __label__grateful4gunsense __label__momsdemandaction
+repbeatty fighting pass paycheck fairness act equal pay deserves equal work happyequalpayday http jto96guqjp	__label__happyequalpayday
+ask question online townhall crowdhall vote favorites http xgqnfwzxnw ar2 arkansas tcot cutwaste sequester	__label__arkansas __label__tcot __label__ar2 __label__sequester __label__cutwaste
+senate dems pledging finally ûò finally ûò produce budget iûªll interested forward	__label__budget
+wise words friend repmcclintock http dgw1iis0ja bordercrisis	__label__bordercrisis
+proud vawa passed house today http m2efnyzjfs	__label__vawa
+tues financialcmte hear fhfa dir demarco agency conservatorship fanniemae amp freddiemac tune	__label__fhfa
+story shared millions americans http lyhehtoja8 let stand 8mill need amp renewui http e2kryk1qjn	__label__renewui
+tripled defense spending 1997 spends defense rest world combined budget	__label__budget
+2014 worked stop nuclear iran confront isis amp support israel yearinreview2014 http okaekkhq9z https malyyyzhtm	__label__yearinreview2014 __label__iran __label__israel __label__isis
+american history marked great moments amp dream martin luther king display today http ahuunwud ar2	__label__ar2
+thanks standing preserve medicareadvantage choice seniors 108 strong repjimmatheson buckmckeon repmckinley	__label__medicareadvantage __label__ff
+photo greggharper repfredupton repmartharoby susanwbrooks recording weekly gop address http ls6ax7aknk	__label__gop
+thrilled introduce familyact sengillibrand good families amp businesses http 48moccxzzo	__label__familyact
+stopped scotus earlier support hobby lobby religiousliberty http p4sanjrdae	__label__religiousliberty __label__scotus
+billclinton newhaven note non coffee drinker group http mx9kklku7t	__label__newhaven
+americans trust obamacare personal data senatemustact	__label__obamacare __label__senatemustact
+heraldnews photos û÷run coryûª event held july capemay corybooker http nzplrfan5a http 0euobswh2l	__label__capemay
+morrow brett man text night bout hiphop hug floor right	__label__hiphop
+renee amp enjoyed hosting nc08 womenûªs symposium friday check article highlighting event indytribune http cnglnz1vtc	__label__nc08
+shouldn choose work family yourtime makinglifework http vdqtw9jlob	__label__yourtime __label__makinglifework
+arfishinhole sutterfield government class ar2 conwayschools http 28z6aclfzs	__label__ar2
+icymi congresstoks town hall weeks ago sabetha http r64el0i6	__label__sabetha __label__congresstoks
+discussed issues veterans roundtable hosted morning including jobs vets http khtmiqpytv	__label__
+news glad interior releasing 475mil sandyrecovery http skoqyox4xh near summer tourist season cont rebuild	__label__sandyrecovery
+proof strong auto strong middle class 000 ford workers receive avg shared profit profit 2013	__label__auto
+new usdol careeronestop website connect vets employers http btil03tyqw	__label__vets __label__careeronestop
+lot wishes list important keystone timetobuild http 5dr9dj7f9h	__label__timetobuild
+barackobama 6th sotu want know think tweet nc09sotu http 5a4kfgusrj	__label__nc09sotu __label__sotu
+truly honored talk americanlegion vets abt ensure vets support benefits deserve http fk2eeg4gnz	__label__vets
+obamacare vexing small businesses courtesy pittsburghpg http qyzrshdzqg trainwreck	__label__obamacare __label__trainwreck
+today 1870 hiram revels african american serve senate bhm	__label__bhm
+approving keystonexl won cost taxpayers dime read excellent wsj editorial importance pipeline http f2daagz2wk	__label__keystonexl
+icymi repjeffdenham announces heûªll sign hr15 watch interview http ehcxatxild actonreform cir timeisnow	__label__actonreform __label__timeisnow __label__cir
+hoping clemson tigers today ncstate tigers clemson tigerfootball bloodrunnethorange	__label__clemson __label__tigerfootball __label__bloodrunnethorange
+great news manufacturing amp job creation quad cities http oikkhkhkl8 makeitinamerica	__label__makeitinamerica
+choiceact puts education hands parents away bureaucrats schoolchoice opportunityagenda	__label__opportunityagenda __label__choiceact __label__schoolchoice
+worth stand american people http bmpb3gqeta cromnibus	__label__cromnibus
+video ask peter folks home having problems aca website learn protect http pkurrwxxaz	__label__aca
+cosponsor hr36 glad house forming select committee investigate benghazi admin response amp seek justice victims pjnet	__label__hr36 __label__benghazi __label__pjnet
+thanks repmikerogers cosponsoring 2809 delaydefund	__label__delaydefund
+revenue sharing critical house passed waiting action http lmcd1vnzkl lasen	__label__lasen
+presidentobama right superstom sandy amp extreme weather events freak coincidence amp combat climatechange	__label__presidentobama __label__sandy __label__climatechange
+great telephone townhall constituents oh15 night thank participated http 0ceqsominv	__label__oh15
+stop harming kids shok resolution urges states end harmful discredited sexual orientation change efforts http w7ykl79bjs	__label__shok
+yesterday elainenekritz held roundtable snap hunger great hear community needs awp2013	__label__awp2013 __label__snap __label__hunger
+sole purpose fatiguing compliance measures independenceday	__label__independenceday
+talking agricultural leaders americanroyal abt need repeal death tax amp protect food safety	__label__kc
+spkr boehner join dems middleclassfirst waste tax dollars goplawsuit http hiiyrjrpsq http i8ecfwzj8v	__label__goplawsuit __label__middleclassfirst
+prayers families innocent israelis incl american citizens murdered terrorists today jerusalem standwithisrael	__label__standwithisrael
+let defund obamacare state exchanges medicaid expansion continuing resolution http b7kskj3vee tcot	__label__tcot
+senate floor sugar reforms save taxpayers money cbo estimates reforms save million years	__label__sugar
+looking fwd conversation morning thisweekabc sanantonio tune ksatnews cst http 7ouxnhfyp3	__label__sanantonio
+bamericafpi trip visited memorial remember lost tragic day http jofozsr4rx	__label__bamericafpi
+confront treasury secretary potus unrealistic 2015 budget hearing tomorrow americans deserve better	__label__potuss
+sent letter administration protect medicare advantage plans amp affordable az09 seniors http zi3iqjc8nb	__label__az09
+barackobama cuts smart fair people lose jobs stopthesequester	__label__stopthesequester
+dontdoublemyrate aldotcom martha roby senate rise politics address student loan rates http cfese3rmy8	__label__dontdoublemyrate
+happy birthday waysandmeansgop chairman repdavecamp forget follow simplertaxes latest taxreform	__label__taxreform
+pres obama announced cancelling trip asia continue lecturing republicans refusing negotiate notleading	__label__notleading
+mondayreport budget deal means congress farmbill update stopping bullying peter yarrow http mmyjh8xffi	__label__farmbill __label__mondayreport
+work progress 27sow cannonafb clovis proud secure funding senateapprops new housing base http auw3g3529g	__label__clovis
+new season duckdynastyae starts tonight preview williebosshog amp siduckdynasty http rxwfeul8l7 duckdynasty	__label__duckdynasty
+icymi huffingtonpost loss benefits devastating families country renewui http nxknixzirp	__label__icymi __label__renewui __label__p2
+want know expect 7th annual veterans resource fair saturday tune 970wfla amtampabay 50am tomorrow	__label__veterans __label__amtampabay
+jstj88 fwd definitely priority office amp proud join illinois members bring cir advocates sotu tonight	__label__sotu
+peteûªs jobs opportunity fair set mich city visit http i4dyiwxfuw http y8dohzmab6	__label__opportunity __label__jobs
+immediately vawa vote speaking house floor need prevent sequester cuts tune cspan http swns5lcycg	__label__vawa
+housedemocrats immigration reform affect watch http cinftbi81q video amp support cir	__label__immigration __label__cir
+republicanstudy day twitter town hall live weigh irs obamacare hashtag askrsc today 1û	__label__askrsc __label__obamacare __label__irs
+thanks repdavidscott supporting 4351 alzheimerûªs accountability act making priority endalz	__label__endalz
+small business owner years know important local businesses community support week sbw2013	__label__sbw2013
+release taliban detainees alarms afghan villagers http 5hs8aznlvr bergdahl pjnet	__label__pjnet __label__bergdahl
+indexing minimum wage inflation help lower income workers future opportunityforall	__label__opportunityforall
+gruber visited white house times times obama met jobs council	__label__gruber
+days sequestration kicks speakerboehner sending house home house session fixed	__label__sequestration
+welcome home cnyûªs olympian erinhamlin community proud winning bronze teamusa ny22 http pubg5mvaoh	__label__ny22 __label__teamusa __label__cnys
+new study today confirms know true umich fans greatest goblue http xkbod7lqn7	__label__goblue
+spoke fox news night interview state department benghazi surivor watch http xhjigmy1cq	__label__benghazi
+sequestration million cut medical research stopthesequester http 07gb44wuoq	__label__stopthesequester __label__or
+covering pres obamaûªs speech today floor remarks latest jobs pivot http vvnhe1lhew	__label__pivot __label__jobs
+irs gross abuse power founding fathers rolling graves http yzjcaxjpsg	__label__irss
+million seniors people disabilities covered medicare medicare works ûò happy 49th anniversary	__label__medicare
+ar3 lapse approps govt shut 12am amp rogers open essential services http qetrx4niyf	__label__ar3
+itûªs time kick surveillance reform overdrive nsa programs needs things accountability transparency tighter limitations	__label__nsa
+house passed 4031 holding veteransadministration responsible http bgphf6dh8f	__label__veteransadministration
+met usgao arctic policy enviro economic amp natl sec interests region amp prioritize better http jznt4kxike	__label__arctic
+irs bothers gretawire cat bothers http fpq6obq33c	__label__irs
+davidgregory hope obviously critical nation right pieces policy funding tweetthepress	__label__tweetthepress
+recording message troops overseas wishing happyholidays thank service http 1g0ysjcdbq	__label__happyholidays
+thanks came aapi heritage month celebration hosted cmkoslowitz tonight regopark http xb6xouwcce	__label__aapi __label__regopark
+weûªre recovering greatest recession great depression renewui http wp2p0cxl9s	__label__renewui
+wishing native nasa astronaut astroillini best luck mission https omfbjll5sf	__label__mo
+delicious madeinwi story wyttenbachs meat family farm family table http kkkgmsarqa	__label__madeinwi
+congressonyourcorner coupons tell help cityofhayward today talking serve http v5lmjo2zol	__label__congressonyourcorner
+week facebook page got 000th like liked facebook https hyy6tuk7nz	__label__facebook
+happy juneteenth celebrating attending dedication frederick douglass statue capitol http elmkjzmmcj	__label__juneteenth
+excited welcome secretaryfoxx il17 today talk replacing bridge amp need invest infrastructure	__label__il17
+tonite great moment history thrilled play role bringing families historic occasion civilunions	__label__civilunions
+shared stories realities obamacare ar3 house floor today video http sofpwhidc9	__label__ar3 __label__obamacare
+nebraskaûªs approval new kxl route means itûªs decision time potus http s4d9asrp way yes 4jobs	__label__4jobs __label__kxl
+nikkibama hate strong word thanks liking fridaykitty	__label__fridaykitty
+peterroskam million student loan borrows past loan payments dontdoublemyrate	__label__dontdoublemyrate
+colleagues joining push nsa reform ronwyden senatorleahy senrandpaul senblumenthal martinheinrich endthisdragnet	__label__nsa __label__ff __label__endthisdragnet
+dataact signed law yesterday amp transform gov transparency shedding light runaway spending http c7armahuyy	__label__dataact
+270 000 veterans waiting house renewui 2mil americans deserve brought house	__label__veterans __label__renewui __label__house
+mlivedetroit design team auto delivers mix modern classic beauties http gbrcrqavzj dreamcruise	__label__dreamcruise
+alex greenwood city brentwood international trade event afternoon http agtn7uvff0	__label__brentwood
+appreciate joined town hall rocky carlo morning la01 http q9pdqhrpmk	__label__la01
+ar2 speakerboehner important questions pres obama answer considering intervention syria http 5psy5ilycx	__label__ar2 __label__syria
+canûªt happen soon theellenshow bringbackourgirls joinrepwilson	__label__joinrepwilson __label__bringbackourgirls
+thx federalreserve chair yellen inaugural financialcmte appearance myview dayinthelife http m1yodj4qvx	__label__dayinthelife __label__yellens __label__myview
+icymi earlier today spoke senate floor remediating effects recent cowildfires video http rjdl4ehm	__label__cowildfires
+meridianstar http gyjlbggc0t greggharper discusses kidsfirst act boost funding pediatric medical research gopleader	__label__kidsfirst
+great juddpdeere kyra kellie madeline taylor staff idpol http usrhvohaeu	__label__idpol
+getting ready speak edshow obamacare tonight tune msnbc 20pm	__label__obamacare
+read latest efforts halt irsûªs efforts stifle free speech http m7dgwhrc7n idpol	__label__idpol
+proud southvalley valledeoro thanks secretaryjewell martinheinrich senatortomudall http lbi3aqkmge	__label__valledeoro __label__southvalley
+honored sworn 113th congress yesterday looking forward serving people ok2 http hghlwv9t	__label__ok2
+shameful earmark looks like http 41ykxhsac7	__label__earmark
+essay competition ar2 high school students winner attend president state union address jan http wkbi7grqcb	__label__ar2
+lots mail flags going tn08 constituents today want flag flown uscapitol forû http hqs5xc49ts	__label__tn08
+women earn cents dollar paid men thatûªs fair support equalpay equal work	__label__equalpay
+tn04 supertalk997 minutes discuss obamacare tune	__label__obamacare __label__tn04
+proud support noh8campaign noh8onthehill hope hear good news supreme court equality week http mvjm52pxbd	__label__equality __label__noh8onthehill
+yesterday asked new jerseyans tell stories urgent need restore unemployment insurance benefits renewui	__label__renewui
+satellite radio potus morningbriefing tim farley talking yourtime eastern channel 124	__label__yourtime
+response president fy15 budget request submitted congress today http yee9wezbaf	__label__budget __label__fy15
+irs taxing tanning beds obamacare absurdities washingtonpost column http gbxx0ullxf trainwreck	__label__obamacare __label__trainwreck
+taking photos billclinton amp fans stomping grounds cafe ames teambraley iowademocrats iagotv 3days http pl1qffkes3	__label__iagotv __label__3days
+followfriday new commandant uscoastguard wedding dress riovideo conservation opportunities usda nrcs	__label__conservation __label__ff __label__followfriday
+support keeping children families amp ask supportchiff http ntbfwiybkn	__label__supportchiff
+ummc announce program patients domesticviolence victims ltgovbrown senatorbarb senatorcardin http 0hzandxprh	__label__domesticviolence
+older americans month comes close learn senior scams fraud abuse http mucdirwnxn oam2014chat	__label__oam2014chat
+proud potus amp house dems addressing 607 yearly gap time working men amp women nomadmenpay http 0icpgqwwgk	__label__nomadmenpay
+4yrs aca young adults covered 100m lifetime limits 129m pre existing conditions getcovered amp covered market	__label__aca __label__getcovered
+live caracol1260 mariodb yolycuello address impt sofl issues economy jobs	__label__sofl
+obamacare small businesses experienced premium increase resulting 885 lost jobs http 0p4uhz5jug	__label__tx
+meeting local braceros amp staff amp students university pacific smithsonian braceros exhibit http zusjwvh1s0	__label__smithsonian __label__braceros
+help raise awareness heart disease killer women doesnûªt gored today http bmjha3vwq9	__label__gored
+socialsecurity press conf intro expand benefits lift cap time strengthen program http p0kqauxgzj	__label__socialsecurity
+keeping troops syria matter thought iraq complicated 1000x worse	__label__syria __label__iraq
+check rebuildact wbkotv congressman guthrie shares new manufacturers http kivi5owjrk	__label__rebuildact
+americanlegion iava amvetsnational concernedvets release letters support veteranschoiceact http suriimso7s	__label__veteranschoiceact
+statement syria http ownt6yl1bi	__label__syria
+check new voices4service report celebrating years gettingthingsdone americorps americorps20 http jnj9jz5zbe	__label__americorps20 __label__gettingthingsdone
+national love pet day tbt amp love life holton eat jjthelamb http mliycsqpip	__label__tbt __label__jjthelamb
+obamacare win lose americans rise defundobamacare https ls4orn0njz	__label__defundobamacare
+cirelafaro meet congressman john garamendi advocate clean air earthjustice lclaa lclaasacramento cflclaa rigû	__label__rig
+crucial senate voted scheduled 00am advance safe communities safe schools act 2013 gunsense	__label__gunsense
+kudos panerabread ceo ron shaich taking snapchallenge cutting 40b people hungry http d5z5gzplgw	__label__snapchallenge
+ûïobamacare wasn competently run û theatlantic housecommerce hearings look obamcareanswers http icfqsryezb	__label__obamcareanswers
+thank eddavis3 riveting amp informative discussion public safety means bostonstrong http v34o2bcifp	__label__bostonstrong
+house dems 100 day action plan middleclassfirst	__label__middleclassfirst
+public benghazi select committee hearing scheduled sept 10am witness list http 1bzq0w7fag tcot	__label__tcot __label__benghazi
+stopped willow grove company support annual pork bbq plenty left come southjersey http i4ycwmj24f	__label__southjersey
+stop feds locking away north carolina beaches obx beaches belong http asqzuomykh	__label__obx
+ocare medical device tax cost nation 000 jobs unacceptable http hibqcgzm0d lasen	__label__lasen
+join deborah comerica park work help end breastcancer follow komendetroit amp register run walk	__label__breastcancer
+photo edenprairie office delivered local student valentines veterans vaminneapolis happyvday mn03 http yywcqfhr	__label__veterans __label__edenprairie __label__happyvday __label__mn03
+students telling congress dontdoublemyrate answered members needed force vote http fk94jgcrbh	__label__dontdoublemyrate
+remember follow facebook continue conversation 140 characters https jmllw82g0i	__label__facebook
+courierjournal jrcarrollcj senator mitch mcconnell meeting president obama isil threat http lg3njrrjbp	__label__isil
+confidence learned lessons tragic attacks consulate benghazi http q7loruw5kb	__label__benghazi
+proud niagara falls 2014 standagainstracism ywcausa https dgx3ym4zho	__label__standagainstracism
+interview niawapo posttv discussing marchonwashington legacy http 9lbibnpza2	__label__marchonwashington
+proud wonderful children aliciamenendez amp rob fathersday http nwxsodhbqz	__label__fathersday
+huskies homestretch bleedblue canines uconnwbb	__label__bleedblue __label__canines
+icymi minnpost article amyklobuchar bipartisan bicameral work combat sex trafficking notforsale http aoex39vvge	__label__notforsale
+today house voting creating jobs building keystonepipeline think timetobuild http xxfc8zsynx	__label__timetobuild __label__keystonepipeline
+relieved hear gsfoundation team safe accounted bostonmarathon santabarbara	__label__santabarbara __label__bostonmarathon
+posigen solar company looking expand new york state http yqntae2hok albanybizreview	__label__solar
+wearing ups browns ready hand deliver packages good people mn08 http giz5aredth	__label__mn08
+ready sb48 broncos unitedinorange http drsj0dimko	__label__broncos __label__sb48 __label__unitedinorange
+senangusking penned explaining student loan repayment proposal http seamjnt1zu fixthemaze	__label__fixthemaze
+enjoy espn wastebook exposes list favorite sports teams want http ws8mpahscf	__label__10 __label__wastebook
+nearly 000 illinoisans longer need snap raisethewage http g8pwqwydgg talkpoverty	__label__raisethewage __label__talkpoverty
+chrislhayes highlighted special tax giveaways fiscalcliff deal worth sharing http kv0p9fj2	__label__fiscalcliff
+thehill new regs power plants cost thousands jobs amp billion annually uschamber http yqcnejbbhf tcot	__label__tcot
+thanks attended 2014 briefing nwtc today wi08 http voaiigujka	__label__wi08
+vote amash conyers massie mulvaney polis amdt today rein domest surveillance innocent americans rep vote nsa	__label__nsa
+jaylow fridaykitty putin russian war syriaously http eo03hrjnnz	__label__fridaykitty
+wonder pentagon misplaces marine col active duty benghazi http bztgmtfe6k	__label__benghazi
+going vote keystonexl approval right	__label__keystonexl
+introducing path prosperity board game gopbudget hard ahead http d0rvuswfjz	__label__gopbudget __label__p2
+nofilter today senator baldwin introduced piece legislation senate http tuqbpwkmck	__label__nofilter
+congratulations paul ferreira newly minted eagle scout sanramon ca15 http ldx1hc6tgj	__label__sanramon __label__ca15
+discussing latest ukraine wolfblitzer cnn minutes	__label__ukraine
+proud joined repwalorski pass expanding military whistleblower protections http y7nwkdfpdu mn03	__label__mn03
+video calls army corps plan restrict fishing dams unreasonable watch press conference http ykzhf9vcnh tailwaters	__label__tailwaters
+floor note youth traffic safety month motor vehicle accidents continue leading cause death teens	__label__youth __label__traffic __label__teens __label__safety
+photo proud sign repjoeheckûªs kids help create jobs https huappsfkhi	__label__nv __label__jobs
+powerhrg plans create 200 il05 jobs year thanks making 200 families happier http vzekxyfksy	__label__il05
+missed opening statement today fisa hearing youtube page http ueqw5uqsfq hjc113	__label__fisa __label__hjc113
+new aecfkidscount report finds children live poverty http fl8qx5gmqy better better kidscount	__label__kidscount
+proud standwithpeggy pregnant workers shouldn choose healthy pregnancy paycheck http qturgqrr1z	__label__standwithpeggy
+spendingistheproblem 52k share national debt http rj7npkc6ds	__label__spendingistheproblem
+prekforall opportunityplan empower working women thrive 21st century economy investinkids http 2e1ut4rr2y	__label__prekforall __label__investinkids __label__opportunityplan
+effectively combat terrorism sacrificing civil liberties free resetthenet http 4xjnxkooek	__label__resetthenet
+tune foxnews joining america news headquarters talk debtceiling	__label__debtceiling
+breaking news prediction 2013 ncaa championship night msnbc http 8fbbpnpatt ohiostate edshow	__label__championship
+new report shows gov save billions ending handouts agribusiness http qsxqsndpku corporatewelfare cropinsurance	__label__cropinsurance __label__corporatewelfare
+housescience astronauts introduced nasa read day history 1959 http f5eb8jpkhx	__label__nasa
+pls join celebrating pridemonth glad right history https s6awb2wsul	__label__pridemonth
+senleepresssec watch senmikelee town hall meeting west jordan streaming http ekds7lyqgqû utpol leetownhall	__label__utpol __label__leetownhall
+blocking immigration reform house republicans single handedly hurting economy timeisnow http oisjkppgts	__label__timeisnow __label__immigration
+vet lost 700 ignored violation principle promote protect http gihnxltn8z	__label__va
+need work corps engineers quality work timely manner lets projects moving waterresource	__label__waterresource
+stand 2nd amendment rights signing petition http 8wkqcif4zj stopatt	__label__stopatt
+kentuckybaeo pastor jerry stephenson working hard promote school choice initiatives kentucky	__label__kentucky
+potus credible determine best interests israel http 6jyq2kv5	__label__israel __label__potus
+burden student loan debt affects borrowerûªs ability buy home plan retirement need fairshot	__label__fairshot
+great day southeast ar1 discussing 2014 farmbill implementation lake village http cq4unlxeym	__label__farmbill __label__ar1
+murray 20wk abortion ban matter introduces going senate http wna5b3lbdp standwithwomen	__label__standwithwomen
+need stopthesequester pass balancedbudget puts ny18 families work	__label__ny18 __label__balancedbudget __label__stopthesequester
+read statement epa ûªs new rules existing power plants http wwii2neezc	__label__epa
+guy ca49 http ilntqltmx0	__label__ca49
+march 3rd deadline apply federal student aid visit http t8tng0gv started today fafsa education	__label__fafsa __label__education
+watch speech marketplacefairnessact http ccwhx3chwg	__label__marketplacefairnessact
+raylahood new locomotive built americans usdotfra better way celebrate natl transportation week http gsj17tomr2	__label__transportation
+comfoodjustice need work better definition rural means repjimcosta fairfarmbill farmbill	__label__farmbill __label__fairfarmbill
+sen murray care deficit need care climate change http azt8vr7tiv actonclimate	__label__actonclimate
+getting town hall meeting moapa valley started nv04 http kd3lzookih	__label__nv04
+took nearly hour filibuster congrats senrandpaul finally getting response administration standwithrand	__label__standwithrand
+violates 4thamendment gorman siobhan house intel cmte restructuring nsa phone prgm sets clash judiciary cmte	__label__nsa __label__4thamendment
+joined jeff lennhardt john amp mitchell murphy andrewconnollymakeadifferenceday dubuque http 5mpxaawcfo	__label__andrewconnollymakeadifferenceday
+mins house floor arguing gopshutdown telling house enoughalready tune http 6talxbpx5u	__label__gopshutdown __label__enoughalready
+farmbill includes language authored states cwa intended regulate water runoff logging roads idpol	__label__farmbill __label__idpol __label__cwa
+workers fmla leave 100 million times whatmothersneed paidfamilyleave use care family	__label__whatmothersneed __label__paidfamilyleave
+pell grants amp student loans allowed siblings amp college dad got sick amp leave job dontdoublemyrate	__label__dontdoublemyrate
+john attended remembrance ceremony today capitol steps read statement http jjzmk1as7j remember911	__label__remember911
+watch cspan live tues senate judiciary committee holds hearing constitutional amdt getmoneyout politics start time 30am	__label__getmoneyout
+oklahoma prayers endure day severe weather outbreaks tornados	__label__oklahoma
+case missed great story kpcc cirmeansjobs briefing held morning repjeffdenham http bi99xua8uu	__label__cirmeansjobs
+years roevwade recommitting passing laws save lives unborn children amp protect women prolife	__label__roevwade __label__prolife
+ready work darrellissa finish job restoring postal service long term solvency committed getting 113th	__label__113th
+veteransday amp everyday remember amp thank selfless veterans sacrificed nation safe https tacqf2q0vr	__label__veterans __label__veteransday
+proud stand daddies amp oregon biz fight nonettax new blog visit daddies http rtjoqsgryp	__label__nonettax
+delaying keystonexl harm environment irony timetodecide http 0ggd8darps	__label__irony __label__keystonexl __label__timetodecide
+lots going come houseforeign tomorrow subcommittee hearing lebanonûªs security challenges interests http iq5pmmyz5p	__label__lebanons
+staff repgaramendi house floor talking jobs amp tax policy watch http ki8p6was cspan	__label__cspan
+getcovered waplanfinder jessica spokane gone 2yrs meds amp enrolled waplanfinder http 3tkuwdklu5	__label__spokane __label__getcovered
+regrettably house failed approve proposal new farmbill frankly shocked outcome http 6wsv6dek9a	__label__farmbill
+senatorisakson house ga09 standuptoreid pass defundobamacare senatemustact	__label__ga09 __label__senatemustact __label__defundobamacare __label__standuptoreid
+tim howard ussoccer played strong half need sure advantage quality looks offense teamusa ibelieve usmnt	__label__usmnt __label__teamusa __label__ibelieve
+plaza colombia celebration saturday sun life stadium celebration sunday colombia miami	__label__colombia __label__miami
+senjohnthune applaud house passage approve keystonexl president blocked project amp 000 jobs 706 days	__label__keystonexl __label__jobs
+obamacare insure million fewer previously estimated according cbo http 2dxmtefom5 trainwreck brokenpromises	__label__obamacare __label__trainwreck __label__brokenpromises
+mcconnell constituents kentucky accept tax hike place spending cuts agreed parties sequester	__label__kentucky __label__sequester
+right vote cornerstone democracy reaffirm right making sure youûªre registered http wwricc5hlz celebratenvrd	__label__celebratenvrd
+day researchers getting closer finding treatments cure alzheimers great job harvard http 35zt2nx5ae	__label__alzheimers
+20th western caucus day proud lead caucus fighting west years follow westerncaucus	__label__west
+excited barackobamaû÷s mybrotherskeeper initiative important effort expand opportunity young men color nation	__label__mybrotherskeeper
+cent spent obamacare sign petition agree http 09ukxejdvt	__label__obamacare
+today remember brave individuals lost lives attack pearlharbor http togmj4nqvl	__label__pearlharbor
+congress introduced address teen pregnancy senatorboxer http tofz4tfmop latinachat	__label__congress __label__latinachat
+wasnûªt commitment unions min wage workweek workplace safety standards happylaborday	__label__happylaborday
+congrats pharmajet colorado company fda approval itûªs need free injectors http 1sqinegt7k	__label__colorado
+rmazetns hasc ndaa includes provision requiring services body armor specially designed women sez repmiketurner	__label__hasc
+hard hide responsibility harryreidsshutdown senate rejects house passed open national parks https 78dw9ygu1q	__label__harryreidsshutdown
+congrats solonschools scholarship recipients staff presented proclamations today solonchamberoh lunch oh14	__label__oh14
+repmaloney new study higher cancer rate 1st responders zadroga act necessary http 1mm8dhu7sn	__label__zadroga
+excited hear lowe bringing new customer support center indy nice in05 attracting new jobs http rwkwwmgk2g	__label__in05
+spendingistheproblem epa given 100 million grants foreign countries yrs http vgfprgdoim cutwaste	__label__spendingistheproblem __label__cutwaste
+statement senate passing renewui urge speakerboehner bring bipartisan vote week http fuybvhrzj4	__label__renewui
+watch remarks hres573 bipartisan resolution condemning nigerian girlsûª abduction bringbackourgirls http gd2rxychfa	__label__hres573 __label__bringbackourgirls
+hazlet business owners association sponsoring food drive keansburg help 732 888 8118	__label__keansburg __label__nj
+video remarks today ways amp means oversight hearing taxes amp healthcarelaw http ezq8pputqi waysandmeansgop	__label__taxes __label__healthcarelaw
+archivist tells oversight committee irs ûïdid follow lawû buzzfeed http u7158up1pp pjnet	__label__pjnet
+pattymurray unfortunately rsherman sorry receivers broncos sb48 sorrynotsorry	__label__sb48 __label__sorrynotsorry
+georgehwbush leadership commitment public service http fgvmlcn4l8	__label__georgehwbush
+mikkijenson syria uses response intûªl community prevent iran north korea askheidih	__label__askheidih
+higher medical costs forcing americans care gallupnews http j6eouyngdl obamacare brokenpromises	__label__obamacare __label__brokenpromises
+spent career working stregthenmh time compromise thoughtless divisive attacks http 9vmu09iswe	__label__stregthenmh
+look press releases week fiu israel fpl organandtissuedonation cuba freedomfighters http hx1tuzbd3d	__label__freedomfighters __label__fpl __label__fiu __label__organandtissuedonation __label__cuba __label__israel
+check latest interview gretawire irsscandal lois lerner blackberry http kj7yddkelr foxnews tcot	__label__irsscandal __label__tcot
+visit broadview greatly informed understanding pain caused deportations iûªm glad sec johnson saw	__label__deportations
+50th anniversary marchonwashington minutes read mlkûªs inspiring words http wbq38u6ppv mow50	__label__marchonwashington __label__mlks __label__mow50
+819th engineer national guard deployed week afghanistan thank service http egu4dmai	__label__az __label__afghanistan
+housecommerce notreadyforprimetime itûªs clear admin needed time build exchanges http tniblzhmaû	__label__notreadyforprimetime
+thanks lorettasanchez supporting 4351 alzheimerûªs accountability act making priority endalz	__label__endalz
+barackobama latest keystone delay hurts montana jobs excuses timetobuild http aevkdffwta	__label__timetobuild __label__keystone
+excited going boyscounts 2013jambo west virginia weekend scouting caucus members http udeus4zjo5	__label__2013jambo
+icymi weekend sec vilsack highlighted importance passing long term farmbill http 9pqotr5ih8	__label__farmbill
+economy lose 000 stem grads pass cir costofinaction http hdhsoklmdp	__label__costofinaction __label__stem __label__cir
+davidcarroll3 tnaquarium agree groundhog looking forward seeing fellow vol peyton lift lombardi trophy	__label__vol
+itûªs past time bringbackourmarine sgt tahmooressi pjnet http nxpjpdxuve	__label__pjnet __label__bringbackourmarine
+couple wks ago great dinner grandforks olivegarden friend amp gfherald columnist marilyn hagerty http jwqd7bjkkk	__label__grandforks
+watch financialcmte hearing fha live http amg3cc8qu9	__label__fha
+iûªm disappointed chosen blatantly disregard supreme courtûªs recent ruling amp basic principles federalism	__label__tx
+welcome today path2cures roundtable secburwell nihdirector fda fastercures firstweets mpiresearch cro cocancercenter	__label__path2cures
+politifactri debunks myths obamacare http gfiurdkuvi	__label__obamacare
+join amp thankateacher service kids amp communities week teacher appreciation week http rgwkozxjkf	__label__thankateacher
+watch talk aca tonight hardball piersmorganlive amp megynkelly	__label__aca
+virginiafoxx skillsact cosponsors repkenmarchant buckmckeon replukemesser drphilroe repmattsalmon repstevestivers	__label__ff __label__skillsact
+great spotify available capitol letthemusicflow	__label__letthemusicflow
+today attended dedication honoring braintree veterans served middle east 1990 thankyouveterans http zbgm8hofex	__label__thankyouveterans
+tbt thedemocrats country rise challenge celebrate jfk birthday today http rljhd6qsuh	__label__tbt
+final countdown days president annual budget amp tribeopener hoping good outcomes oh16 http ov5bnyzkdr	__label__budget __label__tribeopener __label__oh16
+usarmy veteran carl wilson served wwii evanstonian amp 101 thank service veteransday http lxtfydaor6	__label__veteransday
+live cte caucus briefing narrowing skills gap america https saualf3hmn	__label__cte
+today 1889 constitution adopted wyohistory constitutional delegates amp friends capitol steps http hln8q9kplh	__label__wyohistory
+sen marylandrieu fights day louisiana amp need fighting senate imwithmary http ziob7o6fbz	__label__imwithmary
+saturday claire hosted celebration local amtrak volunteers kirkwood years service pics https nvicadgywq	__label__mo
+close huge victory women applaud house gop ready help finish line vawa	__label__gop __label__women __label__vawa
+500 delawareans including african americans new castle county hiv gettested http ttdoyv2ddv nhtd	__label__gettested __label__nhtd
+irs commissioner shulman public white house visits cabinet member http qibdxt1avk	__label__irs
+speakerboehner delivering speech today aei based ideas come washington http qzctbs9vui 5pts4jobs	__label__5pts4jobs
+light allegations syria chemical weapons people think response	__label__syria
+irs claims lost emails commissioner lois lerner employees http ajlgrmvmr4	__label__irs
+taxday fact americans spend billion hrs preparing taxes hrs spend mn03 time4taxreform	__label__time4taxreform __label__mn03 __label__taxday
+thanks interior secretaryjewell joining omdp4nm public mtg lascruces appreciate doì±aanacounty residents coming	__label__lascruces __label__doaanacounty __label__omdp4nm
+frigid degrees feels like degrees zero thousands dedicated prolife heroes whywemarch	__label__whywemarch
+amp fdic high risk merchant guidance amp doj involvment housejudiciary hearing watch http ot75ypzceh chokepoint	__label__chokepoint
+tell speaker boehner time vote senate end gop shutdown justvote	__label__justvote
+skillsact confusing http uo5wnwmm2n	__label__skillsact
+iûªm tired rubber stamp nsaûªs surveillance tactics sponsoring tighten standards http p8nlocifz4	__label__nsas
+happy address good group fairviewpark good cuyahoga county oh16 http siqpphzuys	__label__fairviewpark __label__cuyahoga __label__oh16
+stopped avemarialaw earlier afternoon talk students amp faculty issues imp fl25 http iz2knfgl41	__label__fl25
+icymi tues kauai rep tulsi gabbard discussed local nat issues tulsiinyourtown event http docmruanw4 thegardenisland	__label__tulsiinyourtown __label__kauai
+freebeacon story whitehouse benghazi spin reminder need select committee hres36 http nszmfpcajl	__label__benghazi __label__hres36
+enjoyed discussing important issues like older americans act seniors parkway center utica ny22 http 5nbz6mixtp	__label__ny22
+americans need obamacare delay drphilroe came abetterway info american health care reform act http wecsxqgawe	__label__abetterway __label__obamacare
+wishing celebrate happy diwali	__label__diwali
+months petcoke piles uncontained amp facing problems dust contaminated stormwater http p8jwiaeshk	__label__petcoke
+applaud potus legal authority improve broken immigration congress provide cir immigrationaction	__label__immigrationaction __label__congress __label__potus __label__cir
+honored house dem caucus representative dem eboard mtg http cfqjlm6btw	__label__eboard
+spent morning talking radio mo8 new meetings dates onsr gen management plan http eb3rcnuzh1	__label__mo8
+congratulations bend golfer jesse heinly winning usamateur http nf2d7t6xwd	__label__usamateur
+uscismedianynj stanley bussi 5th grade students repgracemeng moments naturalization fieldtrip http iû	__label__fieldtrip
+good luck york county resident danicashirey competes tonight nbcthevoice learn danica http dssnyky31j	__label__danicashirey
+heading senate floor soon oversee debate gangof8 immigration tune span watch	__label__immigration __label__senate __label__gangof8
+senate passed bipartisan highwaytrustfund extension speaker stop playing games jobs pass http i6p5glvvnt	__label__highwaytrustfund
+great participate jobs tour grand hyatt satx week meet hardworking men amp women http kzm6hmcjjl	__label__satx
+fall internship applications friday looking team exceptional students spread word http xxjqyns2fc	__label__nh
+labor leader calls obama adminûªs failures keystonexl ûïgutlessû amp ûïpolitics worst agree http 7rw9wlqre8	__label__keystonexl
+callruby things getting underway workwell event repbonamici http rwuphv6faf	__label__workwell
+tune floor waiting introduce amendment cut irs budget targeting americans tcot	__label__tcot __label__irs
+join û÷conversations ben rayûª santafe tomorrow http 9smeh4x0nt	__label__santafe
+watch senator mike crapo question irs officials senatefinance idpol http laf29m9q8u staff	__label__idpol __label__irs
+watch repdankildee house floor discussing bipartisan legislation renewui http iyggueygp3 hope4jobs	__label__renewui __label__hope4jobs
+hhsgov 750 employees testify tomorrowûªs climatechange hearing http kmehjonhiv	__label__climatechange
+stewsays time potus claims studentloans passed senate blame senwarren mass objected deû	__label__studentloans __label__senate
+arena filled attacks amp political destruction refreshing sens left amp right join forces justice passmjia	__label__passmjia
+visitthecapitol today remember martin luther king anniversary passing april 1968 mlk http v4zfcû	__label__mlk
+economy strong create good new jobs poor path poverty sotu middleclass	__label__middleclass __label__sotu __label__economy __label__jobs
+introduced resolution house today recognition smallbusinessweek shoplocal http stnqtrmr3x	__label__smallbusinessweek __label__shoplocal
+tbt 2008 led adoption mandatory spay neuter law career http 1vjicbisp6	__label__tbt
+acaworks 71k wisconsinites signed coverage http 0v4efdyqdf marketplace getcovered	__label__acaworks __label__wisconsinites __label__getcovered
+disappointed senate blocked student loan affordability act prevent student loan rates doubling dontdoubletheirrates	__label__dontdoubletheirrates
+iûªm proud stand president obama las vegas speaks immigrationaction timeisnow	__label__timeisnow __label__immigrationaction
+univmiami faceoff biggest rivals floridastate seminoles impt game week canefam rooting theu beatfsu gocanes	__label__canefam __label__theu __label__gocanes __label__beatfsu
+taped interview tjdelsanto nca2014 report ongoing effects climate change watch wpri 15pm	__label__nca2014 __label__climate
+today army csm bennie adkins amp spc donald sloat receive medalofhonor god bless service http euhgozlmbk	__label__medalofhonor
+jimwallis important piece massincarceration amp redeem colleague lisasharper sojourners http 6bt1coppnp corybooû	__label__massincarceration __label__redeem
+read statement passage border security supplemental https u63xbhj2h8 bordercrisis	__label__bordercrisis
+cantwellpress right thing pass house let senator reid shut gov obamacare senatemustact	__label__obamacare __label__senatemustact
+countdown wv150 47days randolph county stop oldest festival mountain state forest festival http jx68gbgchz tourism	__label__47days __label__tourism __label__wv150
+days umichfootball kickoff ready goblue http gqnafku0kd	__label__goblue
+today house voted ensure heroes end secret waiting list pjnet http h7c26qmbck	__label__va __label__pjnet
+headed scottsdale event honoring marshall trimble wonderful arizona state historian	__label__arizona __label__scottsdale
+national police week comes close want extend thanks national amp local oh5 law enforcement officers	__label__police __label__oh5
+spoke kusi news telemedicine vets amp service members san diegoûªs innovation econ leading way http fdsx14oeif	__label__innovation
+ca52 innovators starting new ventures iûªm proud stand national entrepreneursday	__label__ca52 __label__entrepreneursday
+waiting potus coequalbranches	__label__coequalbranches
+gop zero attempts repeal obamacare want congress stop wasting time amp focus jobs http 6lsv5vsblx	__label__obamacare
+gianezmusic pleasure honored represent keywest	__label__keywest
+boko haram abduction 200 girls nigeria horrific demand pray safe release bringbackourgirls	__label__bringbackourgirls
+read judy gross appeal release husband alan usatoday bringalanhome ûò http cjnajw2m0q jcrcgw	__label__usatoday __label__bringalanhome
+check latest newsletter http szsoa625gf tx17	__label__tx17
+tbt joined repjohnlewis amp actor activist ijessewilliams whitehouse launch mybrotherskeeper http jtedo6lyzk	__label__tbt __label__mybrotherskeeper
+vote authorization military force syria read http xqqdxmxmge la03	__label__la03
+child held zip codes proud support quality amp choice education charterschoolweek http uecmb16kh6	__label__charterschoolweek
+finding path 21st century cures http a06h8aibdh miss repdianadegette huffpostpol path2cures	__label__path2cures
+potus needs tell doe expedite existing lng permit process amp set firm deadlines doe act pending applications	__label__potus __label__lng
+unlvathletics great photo coach tark statue afternoon unlvmbb http hsoty3jbs1	__label__unlvmbb
+ûï jslconsulting national baldisbeautiful day mess texas repkevinbrady replouiegohmert tcotû great texans	__label__baldisbeautiful __label__ff __label__tcot
+explosive revelations nsa spying wsj http i1iephdshf	__label__nsa
+proud support house provide aid sandy victims natural disaster relief fall victim partisan politics	__label__sandy
+chrislhayesåêlooking forward joining tonight allinwithchris talk elections2014 msnbc	__label__elections2014
+inspiring thedailyshow interview fawzia koofi author amp afghanistan 1st female parliament spkr http bga1rn8i offthesidelines	__label__offthesidelines
+rep griffithûªs va09 staff holding office hours tomorrow marion covington new castle amp bristol http jf8ddfxeho	__label__va09
+hard pay rent minimum wage mn2020 http 3osi7efxph	__label__mn
+urging pres obama help savesaeed http b0ahd6mfen http 5qsaxmfwrd congressmangt congculberson	__label__savesaeed
+congrats olympia williamson 2013 air national guard outstanding guard year proud grateful nationalguard	__label__nationalguard
+government need help federal agency caseworker office mlk library tomorrow 4pm dcpl nortong2g	__label__nortong2g
+icymi ûïappreciation small businessesû thehill smallbizgop chairman graves http llvp7fa4bh nsbw smallbiz	__label__nsbw __label__smallbiz
+epa grants making rehabbing revitalizing mills reality ludlow lee http 7hfipxwsqf	__label__lee __label__ludlow
+wthrcom took bluepledge headed indy neighborhoods tonight nightoutagainstcrime	__label__bluepledge __label__nightoutagainstcrime
+great discussing small business issues today members azrestassn werrestaurants http 8ktuseaylr	__label__werrestaurants
+gopshutdown hitting home johnboehner amp good hoping watches amp finally calls vote ûó http dcwrwmv6mm	__label__gopshutdown
+delegation ukraine hold press conference hour discuss visit livestream https ds517hmuwz	__label__ukraine
+today saluting queenofking jeanenersenk5 covering news area years	__label__queenofking
+agree kirstenpowers10 demand end media blackout kermit gosnell trial http ylzjjewzyl prolife abortion	__label__abortion __label__gosnell __label__prolife
+voter come saturday cast ballot billcassidy votecassidy http cnrarp3dze http j55hwpvanp	__label__votecassidy
+accepted als icebucketchallenge amp nominate dekecopenhaver hardiedavis repsinema amp repmurphyfl watch http kusawr7myp	__label__als __label__icebucketchallenge
+lynch saying deptvetaffairs wrong goals lameexcuses http 9inmtfnw2a	__label__10 __label__lameexcuses
+heading coldest weather record winter backtosession polarvortex	__label__backtosession __label__polarvortex __label__winter
+great discussion today vincennes best address workforce development indiana in08 http yewfbhvrhs	__label__in08
+let nsa threat america talk mother mindyourownbusinessnsa https mrf8htwlgs	__label__mindyourownbusinessnsa
+taking questions forum twitter tweet syria question rep lynch hashtag lynchsyriatownhall	__label__lynchsyriatownhall
+thanks cincybuilders hosting today discuss housing market growing economy 4jobs http 4hietwf5us	__label__4jobs
+democrat joins bipartisan agreement obamacare hurt small business http x1dkg8ip81	__label__obamacare
+wed introducing heaa2014 improve healthequity spoke heaa hill staff today http b0wcu57nct	__label__heaa2014 __label__healthequity
+hosting townhall meeting rock hill week nov baxter hood ctr york tech 452 anderson sctweets	__label__townhall __label__sctweets
+washingtonpost fact checker shoots whitehouse notion smear campaign http rrzkuifgco tcot demandanswers benghazi	__label__tcot __label__demandanswers __label__benghazi
+join colleagues steps capitol morning honor twelfth observation sept11 2001 neverforget911	__label__sept11 __label__neverforget911
+senateag showcase features biobased industry leaders happy welcome springdale biobased technologies http 0gnswwto2z	__label__biobased
+good news glenn county new low loan usda new medical center http b1ghp857gl	__label__usda
+hanging studio lite98 morning shelley rva clear channel richmond http 3dfxoiiuez	__label__rva
+100 fema workers furloughed shutdown harming critical coflood recovery efforts amp end enoughalready lethousevote	__label__coflood __label__enoughalready __label__lethousevote __label__co __label__shutdown
+waysandmeansgop icymi camp talked teamcavuto irs continuing target tea party groups http ti94ra5zxr	__label__irs
+good paying jobs opportunities foundations help build better lives americans wherearethejobs president	__label__wherearethejobs
+heartbroken tonight loss life yarnellfire joyce praying yavapaicounty amp families 1st responders	__label__yarnellfire __label__yavapaicounty
+applaud faanews amp auvsi raising awareness unmanned aerial hobbyists amp fly knowb4ufly https lifay1kdzn	__label__knowb4ufly
+speakerboehner 150 years ago today abraham lincoln sparked new birth freedom gettysburgaddress http gxqg2g4mit	__label__gettysburgaddress
+icymi oped eagletrib ûò real people real consequences renewui http tjnmvnud61	__label__renewui
+vean domingo 1130am oir sobre viaje israel disidentes cubanos enlace norcorea cuba michaelputney wplglocal10	__label__norcorea __label__israel __label__cuba
+ensure iflymia ebola preparedness measures place prevent future health crisis http ntkonuzbm7	__label__ebola
+randy black takes break decorating white house join clear lake parade 4thofjuly iowavalues http jyqimo96fv	__label__4thofjuly __label__iowavalues
+jordan great friend ally mideast pleased support resolution recognizing important partnership peace security	__label__jordan
+hosting roundtable manchester business owners discuss ongoing efforts stop onlinesalestax	__label__onlinesalestax
+blast speaking members cub scout pack 199 sellersville week nation history http nmgvg5iec9	__label__sellersville
+fact states raised minimum wage saw higher job growth states http gzxkjwr7qq raisethewage	__label__raisethewage
+opinion thompson national pta president voice opposition proposal eradicate funding school websites http puy2jtzn2z	__label__pta __label__school
+blowout preventers shd failsafe destined fail new chemsafetyboard rpt oilspill says bops unsafe http mpvja2jgro	__label__oilspill __label__failnew
+weekly ar3 http 5wushzomsw	__label__ar3
+jackietortora keithellison itûªs time standup2shutdown amp furloughed workers work join tomorrow outside caû	__label__standup2shutdown
+today visited tropicana amp packers indian river facilities fl18 discuss localjobcreation http yig9sbii	__label__fl18 __label__localjobcreation
+people work hard jobs safety net support itûªs time act renewui	__label__renewui
+psychgallica sequester lead furloughs arsenal amp job losses opposed askdems	__label__askdems __label__sequester
+signed weekly oh14 newsletter click add mailing list http f4pii0mup7	__label__oh14
+obamacareûªs definition time employment working hours week hurting economy workers	__label__obamacares
+prettygirlceo officialcbc watch rep yvetteclarke speaking http r3gsgw0rlh cirnowåè	__label__cirnow
+voted defund obamacare today senatemustact	__label__obamacare __label__senatemustact
+new federal investment support highway safety amp distracted driving prevention initiatives http beaeywozp8	__label__wv
+creating jobs opening new markets major priority house colleagues 4jobs http xzk8uco8rk	__label__4jobs __label__jobs
+agree equalpayday letûªs sure americaûªs hardworking women equal pay deserve http ikwsloy3bj	__label__equalpayday
+lost 000 manufacturing plants 2001 detroit	__label__detroit
+new bipartisan agreement renewui let excuses act gop come time http 3khzdxhjth	__label__renewui __label__gop
+pausing honor tiananmen stood human rights democracy china http rdrkwh4nhj http tv1ncieloa	__label__tiananmen
+country offered basic bargain hard work wld rewarded fair wages benefits abetterbargain raisethewage	__label__raisethewage __label__abetterbargain
+look city showed jeopardy tonight youngstown ohio trebek http n3ius47sd6	__label__jeopardy __label__trebek __label__ohio __label__youngstown
+kelly going mean higher premiums higher costs rateshock http b9edvjum4p	__label__rateshock
+time help familiessucceed modernizing workplace policies http eiiwat8jwh http mvbdla3x8j	__label__familiessucceed
+came 20yrs ago commitment moms sisters daughters friends violence place relationship vawa20	__label__vawa20
+indiana ranked 2015 state business tax climate index http kcq7kaijxr economy jobs indiana	__label__indiana __label__economy __label__jobs
+pleased join unitedwayatl myyplatlanta luncheon spking leadership prof devel amp public service http tqvvmlmccj	__label__myyplatlanta
+heading senate floor sendeanheller try advance bipartisan renewui help job seekers watch live http ngyhwbgyec	__label__renewui
+million men women children lines climatechange ûò number grow http yuebzzavvh	__label__climatechange
+lot areas government cutwaste little pain inflicted hardworking americans http 4f1y5xmd2q	__label__cutwaste
+click listen sotu reaction interview krdonewsradio http gvkwvnd5er	__label__sotu
+lowtheband hey voted farmers mrkt prgms farm amp voted bring troops home afghanistan soundoff	__label__soundoff
+nhpco news thank senator markwarner end life care planning act 2013 eol hospice hpm http gnmm3o7n45 shaû	__label__hospice __label__hpm __label__eol
+voted clarify faa cutwastenotworkers	__label__cutwastenotworkers
+trillion ûò proposed debt 2023 obamabudget	__label__obamabudget
+fmla took effect 20yrs ago allowing americans care loved risking job paidleavenow	__label__paidleavenow __label__fmla
+offshore energy amp jobs act unlock energy production 4jobs create 000 new jobs	__label__va __label__4jobs
+bbcworld radio addressing governmentshutdown implications http 2jvmvqvyzz	__label__governmentshutdown
+innovative conservation projects miss usda nrcs support improve soil health water quality http ruwwcefh6h farmbill	__label__farmbill
+chance question mikeroweworks todayûªs natresources hearing american energy jobs watch http qjvcq7ooeh	__label__jobs
+today historic day american comprehensive immigration reform passed senate urge house act cir latism	__label__latism __label__cir
+heading house floor fight greatlakes amp michigan jobs offering bipartisan amendment rep hahn	__label__greatlakes
+earthday think globally act locally protect environment	__label__earthday
+workforce investment act wia critically important getting americans work meeting modern demands businesses	__label__wia
+video sen sanders talks toure krystalball1 stevekornacki amp secupp thecyclemsnbc http amuqsr2ych budget	__label__budget
+thehawkeye editorial board calls proposal 28m american workers raise amp raisethewage thing	__label__raisethewage
+columbiatribune overnight shelter set como church power http xzyazkmfo3	__label__como
+video college students tell senatedems obama dontdoublemyrate http ku3zvn8wjf	__label__dontdoublemyrate
+thatûªs nearly 200 colleagues petitioned speaker boehner allow vote raising minimumwage raisethewage	__label__raisethewage __label__minimumwage
+irs employees interviewed including self idûªed republicans political motivation role irs http scm9dfweho	__label__irs
+1st amendment protects religiousfreedom amp american compelled violate convictions hobbylobby	__label__religiousfreedom __label__hobbylobby
+keeping pressure watch live stream capitol hill hearing commissioner koskinen http hytbu3hybm	__label__rs
+catch visit smccmaine maine advanced technology amp engineering center brunswick http trmjlkpbty mepolitics	__label__mepolitics
+constitutional responsibility incumbent ensure war divided maddow	__label__maddow
+coming pier touring harbor special panel freight transportation http skgunig4vn	__label__ny __label__transportation __label__freight
+today 10am housejudiciary hold hearing examine balanced budget amendments tune http daum6bhefb bba	__label__bba
+month fda took welcome step announcing revise proposed fresh produce rules http 1hr8oiqxj9	__label__fda
+wonderful costumes diadelosmuertos festival onlyindistrict1 http 7bjwqikd4c	__label__onlyindistrict1 __label__diadelosmuertos
+president calls modern pipelines job creating keystonexl pipeline timetobuild sotu	__label__timetobuild __label__keystonexl __label__sotu
+people losing insurance getting asksebelius http sql4empiyd	__label__asksebelius
+cbsthismorning discuss today msthearing examining sexual assault military video http ul0i9o7vkw	__label__msthearing
+happy 67th birthday usairforce thank men women serve protect nation afbday	__label__afbday
+irtl toddrokita life precious abortion tragedy gosnell	__label__gosnell
+join sweettea tim searcy monday morning details https tdyjegcw87 ar2	__label__ar2 __label__searcy
+waysandmeansgop obama middle class incomes fallen time focus taxreform fix economy http	__label__taxreform
+recently held coffee congressman event clay county read event http ektcxnza1e in08	__label__in08
+supporting fast4families national day act fast pray immigration reform timeisnow http nppdd8tmue	__label__fast4families __label__timeisnow
+todayûªs jobs report shows job growth far potential itûªs timetobuild keystonexl 4jobs http 6qmuhbu07a	__label__timetobuild __label__4jobs __label__keystonexl
+nevadawolfpack kaepernick7 best breakthrough athlete congrats battleborn espys	__label__battleborn __label__espys
+watchdogfla fla repdennisross condemns nsa email spying offers relevancyact solution http l2kfgg5uhy	__label__nsa __label__relevancyact
+good news lgbt seniors equality means potential fewer seniors living poverty http 8gk1ywvppu	__label__lgbt
+vawa provided million enforcement amp victimsûª services iûªm pushing continue crucial support	__label__vawa
+fmla helping families years need paidleavenow npwf	__label__paidleavenow __label__fmla
+health industry officials obamacare related premiums double parts country thehill http pgqkgknzoc	__label__obamacarerelated
+president steps right securetheborder amp safely return children home http 2dk6rf2nkx bordercrisis	__label__bordercrisis __label__securetheborder
+wirenut1990 speakerboehner repandyharrismd 37th time isn charm acarepeal doa senate let work	__label__acarepeal
+families lighting menorah tonight sundown happy hanukkah chag sameach	__label__hanukkah
+congrats lakeville north win roseau boys state hockey tournament good luck tomorrow semis mshsl thetourney14	__label__mshsl __label__thetourney14 __label__lakeville
+senjohnhoeven setting record straight keystonexl benefits creates approx 100 jobs lowers gas prices info httû	__label__keystonexl
+today joined colleagues end gopshutdown reopen government real business http rbmcdjxqdp	__label__gopshutdown
+best luck impressive students representing 2014 nationalhistory day competition nhd2014 http mrqnnypsno	__label__nhd2014 __label__ri
+pleased senate voted renewui urge house action nevadans canûªt wait http a88tlds81u	__label__renewui
+dday footage tears think sacrifices heroes charging nazi guns amp horrors war madness hitler sherman right	__label__dday __label__heroes
+repjohnkline released joint statement nlrb nominations http w2omdbw69f edworkforce	__label__nlrb
+enjoyed touring tuthilltown distillery today gardiner impressed ralph amp team great job ny19 http skbzl643gp	__label__ny19
+hours left avoid gopshutdown enoughalready	__label__gopshutdown __label__enoughalready
+sept 2nd active duty military personnel families visit bluestarmuseums free neaarts http 4frggsvaqh	__label__bluestarmuseums
+getting stage speak netroots nation watch live stream speech link nn13 ca17 http ao0vdohdxx	__label__ca17 __label__nn13
+stand ucsd students today speak support affordable college education	__label__ucsd
+member staff holding mobile office hours today winchester winchester city hall wall street 10am ky6	__label__ky6
+sen mcconnell meet press obamacare ûïthe president think parts law ought implemented	__label__obamacare
+year later republican party gotten year older sameoldparty http tuzo6lpbb0 http givdm9lc5t	__label__sameoldparty
+house recess reach deal avert irrational sequester nodealnobreak	__label__nodealnobreak
+spoke chained cpi yesterday capitol press conference watch http grrplq2exp socialsecurity	__label__socialsecurity
+thanks ca13 eastbay thoughts syria vote authorization military force http nnd7wr0dya	__label__ca13eastbay __label__syria
+great win tonight redwolvesfball mobile congrats great game howlyes redwolves brickbybrick	__label__brickbybrick __label__howlyes __label__redwolves
+siadvance putting sexual assault cases hands unbiased mil prosecutors instill new confidence military justice passmjia	__label__passmjia
+easynan2 interesting spend gop won bring jobs floor spend create jobs askdems	__label__askdems
+fun happy safe 4thofjuly weekend la02 happy4thofjuly	__label__happy4thofjuly __label__4thofjuly __label__la02
+joining barry young famousoneradio studio hour 550 kfyi phoenix listen live http ewrhzbvig4	__label__phoenix
+today nwyc presented award commitment serve constituents priority mi11 http tellv925ig	__label__1 __label__mi11
+dodgers	__label__dodgers
+joined 23wifr rockford chamber annual dinner discuss need grow rockford area economy http 39ust2xd il16	__label__il16
+packed house chase field dbacks opening day	__label__dbacks
+va06 staff open door meeting today elkton community center details http 0o2x9yx9ug	__label__va06
+child blessingnotburden thank mikekellypa supporting pro life protect children disabilities http cy796en06x	__label__blessingnotburden
+019 763 americans enrolled aca receiving financial assistance glad people experience affordable quality care	__label__aca
+today 3rd birthday obamacare law brought skyrocketing premiums higher taxes amp freedom american families	__label__obamacare
+met illinois community banks discuss reg relief local banks lending families amp small businesses http rp6pfk37hu	__label__illinois
+nearly years washingtonmonument reopening 12th starting today book http uujynqqahj	__label__washingtonmonument
+fact congress raisethewage weûªd pump billion economy create 000 jobs http b0sefshnqt	__label__raisethewage
+honored welcome naacp naacp105 onlyindistrict1 naacplv 50thanniv civilrightsact freedomsummer mandalaybay http qeg3z10qcq	__label__50thanniv __label__civilrightsact __label__mandalaybay __label__onlyindistrict1 __label__freedomsummer __label__naacp105
+obama admin says ûïno rush decide keystone pipelineû http qizgwu8hzc jobs depend	__label__keystone
+time cutwaste choosing national security vacant federal properties http 0rtaly45tw	__label__cutwaste
+convening aviation subcommittee hearing 10am cause delays faa nextgen modernization program watch http 3dq2m4ldqh	__label__aviation __label__faas
+thank sarahpalinusa backs sentedcruz senmikelee http sxkcgb8qvf defundobamacare	__label__defundobamacare
+potus holds end year presser today ask concerned jobs middle class open atlantic coast energy vaenergy	__label__vaenergy
+tune loudobbsnews 30pm tonight discuss isil benghazihearing	__label__benghazihearing
+proud dad air force vet son join today jonesboro vet parade veteransday http 1upydqwala	__label__veteransday
+newark batting 3rd llws opener let boys llws netde	__label__netde __label__llws
+check grants newsletter info federal funding opportunities amp updates awards http 565ssquvl8	__label__grants __label__cts
+congrats nobelpeaceprize recipients malalayousafzai amp satyarthi boy amp girl rich poor deserves education malalafund	__label__malalayousafzai __label__nobelpeaceprize __label__education
+lrafb community council meeting ar2 http 7gpgevwx05	__label__lrafb __label__ar2
+tweeting obamafailures half hour returned churchill bust gift lied british embassy tcot	__label__46 __label__tcot __label__obamafailures
+annual û÷day silenceûª calls attention û÷silencing effectûª anti lgbt bullying http uvzfetzlky dayofsilence	__label__dayofsilence
+awesome ar2 washingtonpost powerful photo frederick douglass great great great great grandson http iazv2opxz3	__label__ar2
+housecommerce subenergypower unveils draft legislation protect consumers higher energy costs http ylowrmei0l	__label__energy __label__subenergypower
+edshow discussing tpp called free trade agreement isn actually fair american businesses amp workers	__label__tpp
+proud support communitysafetyact nyclu bradlander jumaanewilliams	__label__communitysafetyact
+gopoversight benghazi hearing examine deficiencies statedept internal review benghazi terror attack	__label__benghazi
+thanks taking poll believe washington spending problem believe reducing http toqpsx0ahf ar2 arkansas	__label__ar2 __label__arkansas __label__spending
+repdesantis americans expect play rules rest country fighting end unfair obamacare subsiû	__label__obamacare
+march womenûªs history month women succeed america succeeds read statement http zzydwjlic0 womenshistorymonth	__label__womenshistorymonth
+happy constitutionday proud stood boldly declared founding principles ogh http hdtvkwk42c	__label__constitutionday
+icymi nytimes cont meet constituents hear thoughts immigration debate az05 http u9yasj4sjh	__label__az05
+thanks obamacare work week rule wages drop voted restore work week http ebsonmjuth	__label__obamacares
+obamacareinthreewords protected privacy lol	__label__obamacareinthreewords
+worldhepday hepatitis goes widely undetected usåê amp disproportionally affects baby boomers tested http gdbecoybpj	__label__worldhepday
+robertûªs round july monthly video address http uvghyi5qmh va5	__label__va5
+erin9cotton likewise thank involved agriculture excited mhyneman amp ar1	__label__ar1 __label__ar
+sirius potus morningbriefing tim farley talk equalpayday hope listen	__label__equalpayday
+todays filibuster blow economy amp looking stay afloat job hunting continue efforts renewui	__label__renewui __label__ui
+today sen murray met kennewick woman searching vietnam era pilot remains http 7gpakngkuu http fuuqnbym1z	__label__vietnam __label__kennewick
+glad join njea retired teachers monmouth county today thanked dedication youth amp years service	__label__nj
+hope letyourvoicebeheard elaina32 hope amp senate members understand monday bombarded renewui	__label__renewui __label__letyourvoicebeheard
+letter members dem cong del jerrybrowngov urging seek drought relief assistance http ntexawchmj	__label__ca __label__drought
+obamacare great obama administration delaying key parts law http zsga2iddvn txcot txgop dfw	__label__txcot __label__obamacare __label__txgop __label__dfw __label__obama
+potus address climate change debate ended sotu	__label__sotu
+days left getcovered exchangesûólearn http zfqe0giwvi coveredillinois	__label__getcovered
+launched instagram account sure follow http t0chksgy0d queencitypride http xu9xr0utlz	__label__queencitypride
+happy happy birthday good friend donnabrazile thedemocrats lucky team hbd	__label__hbd
+thanks foreign affairs cmte chair repedroyce cosponsoring 2453 protect choice seniors medicareadvantage	__label__medicareadvantage
+celebrating earthday weekend cleanup weekes park cityofhayward ca15 http 7y9ottf8el	__label__ca15 __label__earthday
+appreciate senmarkpryor johnboozman protect private land owners amp producers http xdqlgklg1m ar1	__label__ar1 __label__ar
+questions remain benghazi amb rice statements contradicting known intelligence analysis time	__label__benghazi
+law school learned basics buddhist instructor swayneharris practice style yoga meditation	__label__meditation
+texans amp companies like cps helping curb carbon footprint cleanenergy http expcyielcp	__label__cleanenergy
+floor ask issue military mental wellness mind member congress amp ask support hr4305 meps act	__label__military
+joining mitchelreports msnbc today discuss national security amp hagel secdef nomination	__label__hagel
+senatorbaldwin proud work alongside women pattymurray instagram photo things changed tbt hû	__label__tbt __label__instagram
+mainly federal issues zachromano influence state senate role funding askjeff	__label__askjeff
+irsûªs excuses donûªt pass smell test http nb7upjcbom	__label__irss
+natural gas water wells near fracking sites http hsnpivjfrh	__label__water __label__fracking
+reps cummings wilson amp ask usgao look long lines polls november particularly amp http 17ut9yzvlm wtop	__label__va __label__fl
+north pole showed force eielson meeting night staffer janelle amp intern haley went http ltmxd1gk	__label__eielson
+6pm tele town hall share thoughts abt shutdown amp debt ceiling proposal 855 269 4484 nc09 clt ncpol	__label__nc09 __label__clt __label__ncpol
+years aca law 105 million americans received access free preventive services healthcare4all	__label__aca __label__healthcare4all
+support intelligence authorization today http gcfxql1gn4	__label__intelligence
+floor speech requireaplan act force pres balance budget http etrbvmws	__label__requireaplan
+economy fragile extreme austerity http zdcgnaeh sequestration	__label__sequestration
+week review http juqapnrpn0 vermont boston guns budget2013 gasprices	__label__vermont __label__guns __label__gasprices __label__budget2013 __label__vt __label__boston
+jobs paul ryans budget crucial investment cuts amp tax loophole preservation gopbudget http vsrhcppzi0	__label__gopbudget
+enjoy mtg leaders lvbiz community lvchamber eggsandissues transportation uav i11 biz jobs http nlqj7oq2w0	__label__biz __label__lvbiz __label__i11 __label__uav __label__transportation __label__jobs __label__eggsandissues __label__leaders
+need help let lawmakers know support reed heller bipartisan compromise renewui	__label__renewui
+surprise obamacare problems surface abcnews report health law sign ups dogged data flaws http wbighv6iqu	__label__obamacare
+francie57 housedemocrats want endthesequester amp plan important economic stability certainty amp jobs askdems	__label__askdems __label__endthesequester
+housecommerce hearing started obamacare asksebelius brokenpromises watch http lpgfpn0m47	__label__obamacare __label__brokenpromises __label__asksebelius
+repmarktakano stand bullying support spiritday http jgkd2vxtle	__label__spiritday
+watch benghazi hearing live today 30am http n58o18xzts	__label__benghazi
+good morning oh14 busy day ahead stop lubrizol lakecounty	__label__oh14 __label__lakecounty
+maxwell amp jacek uwmadison usstudents visited promote affordable higher education amp fairshot http la1fq7h68g	__label__fairshot
+americaneducationweek thanks educators amp nationwide educationweek neatoday nearhodeisland edvotes aew2014	__label__aew2014 __label__americaneducationweek
+potus eager negotiate putin syrian issues refuses negotiate congress american issues	__label__potus
+new forest service report reinforces current way government budgets wildfire suppression unsustainable idpol	__label__idpol
+obamacare law land amp millions women benefiting political games hurt standwithwomen	__label__obamacare __label__standwithwomen
+tune help committee begings 7th hearing retirementsavings broadcast live cspan http yq4dr0c4	__label__retirementsavings
+proud join colleagues today unveil usprogressives caucus betteroff budget	__label__betteroff
+voted making college expensive act passed house majority dropthatdebt dontdoublemyrates http dck6cth5c4	__label__dontdoublemyrates __label__dropthatdebt
+join amp naacp today floridacity youth activity center day aca enrollment activities getcovered	__label__aca __label__getcovered
+thanks rephorsford helping human real life face need renewui fight middle class http gbxfalqzrd	__label__renewui
+chatted peacecorps volunteers manila congressional delegation trip asia http ldfvtr8tn9	__label__manila
+following redmillennial hoping involve hear youngconservatives stay touch stay involved fl19	__label__fl19 __label__youngconservatives
+today introduced congressional resolution wishing sikh community joyous vaisakhi http rq6d6qhu7l	__label__vaisakhi __label__sikh
+shall time time congress information state union hope hear president speech sotu	__label__sotu
+gop mentioned earthday congress 2010 republican environmental agenda http aq61obqjeq green	__label__green __label__earthday __label__gop __label__p2
+net neutrality real issue karen small biz owner read internetslowdown hit line http ovn4xyymt1	__label__internetslowdown
+thank served uniform courage inspires sacrifices ensured freedoms happy veteransday	__label__veteransday
+congratulations redsox 2013 world series champions bostonstrong	__label__bostonstrong
+smooth washdems chair jaxonravens mailedit sure mail ballot november 4th waelex https g4wpohuoep	__label__mailedit __label__waelex
+targeting conservatives day partying night irs http buttgweiof gopconference	__label__irs
+affordable birth control critical economic issue millions american women notmybossbusiness http uakb0grz0w	__label__notmybossbusiness
+great article elkharttruth everythign know july4th http hu5fxfcqql	__label__july4th
+kansascommonsenseûóurgent child migrant crisis rate program ensuring rural depts resources amp http jzgjtmdygi	__label__kansascommonsenseurgent
+poll majority americans want reduce deficit balanced way stopthesequester http ax6r1nmhg0	__label__stopthesequester
+wwu peacecorps volunteers countries 885 time pctopcolleges http jcotbhep	__label__pctopcolleges __label__wa __label__volunteers
+message obama oppression cuba wont change castro brothers charge activists arrested rally yotambienexijo	__label__yotambienexijo __label__castro __label__obama __label__cuba
+senatormenendez today nationaladoptionday let raise awareness 100 000 kids america waiting permanent lovingû	__label__nationaladoptionday
+thx straffordcap thanks warm welcome repanniekuster staff communityaction looks forward working	__label__communityaction
+signing discharge petition raisethewage new mexicans working time shouldn living poverty repadamsmith	__label__raisethewage
+lgbtpridemonth rededicate principle discrimination place america http nlimb4ui8z	__label__lgbtpridemonth
+janschakowsky dorismatsui nwlc aauw ywca presser 2day hvc215 standupforwomen gop budget values statement	__label__standupforwomen
+payne celebrates 50th anniv civil rights act says best way celebrate congress passing updated vra4today http vfoqalaaw7	__label__vra4today
+head irs testify smallbizgop hearing amp demand answers questions sctweets http zy1gf0fuss	__label__sctweets __label__irs
+audittheirs http l4eg6rr6mf	__label__audittheirs
+way washington control spending problem start budgeting ûò budgeting responsibly http vratj9ni tcot	__label__tcot
+president obamaûªs connected initiative gets important boost support adobe http pr9xmedrm0	__label__connected
+today ptsd awareness day ptsd real amp troublesome returning soldiers afraid offer help	__label__ptsd
+congrats barackobama getting surgeon general extols health benefits restricting 2nd amdt rights happy billofrightsday	__label__billofrightsday
+seattv senmikelee fun photo contest roads utah http l4appx9njn roadlesstraveledutah utpol	__label__roadlesstraveledutah __label__utpol
+cosponsored 2009 simple page prevents irs enforcing obamaûªs takeover healthcare stoptheirs	__label__stoptheirs __label__irs
+instead fighting war cancer tea party waging war cancer patients http 9mavfy9f3y	__label__cancer
+marching veterans little neck douglaston memorialday parade mayor billdeblasio http 3xqvawl9z3	__label__veterans __label__memorialday
+june lgbt pride month lets renew efforts eliminate barriers equality http mepjhaxzaw	__label__equality
+happy 4th july fourthofjuly http y5pyfgkyv9	__label__fourthofjuly
+taxreform closing special loopholes help lower rates amp boost economy http lnwbgvhsqu repdavecamp wsj	__label__taxreform
+tune 2pmmst sjenning5 commencement address dickinsonu graduation deserved honor ndpride http zltegxbocm	__label__ndpride
+wuky senate democrat leadership blocks mcconnellûªs savingcoaljobsact http k4ww8k2uab	__label__savingcoaljobsact
+disappointed amendment restore funding snap food stamp program farmbill failed senate floor today	__label__farmbill __label__snap
+game day swamp gators alive uffootball beattoledo gogators http q5dkbo3hhf	__label__gogators __label__beattoledo __label__uf __label__gators __label__uffootball
+manitou springs takes coenergy level aims 1st power city buildings solar http axw9sbqqts csgazette	__label__solar __label__coenergy
+trillion debt legacy leave children time4solutions http ghvotjhaql	__label__time4solutions
+hrc great news govbrewer vetoes horrendous license discriminate sb1062 http l8avuvsnyxû hrc	__label__sb1062
+president allowing jobs council dissolve hope creating jobs priority http oa6nxbhw	__label__jobs
+sen sanders cnn theleadcnn talking jaketapper cromnibus	__label__cromnibus
+whitehouse time states refusing expand medicaid peopleoverpolitics help millions getcovered http vuxzim8nys	__label__peopleoverpolitics __label__getcovered
+introduced manufactured housing house financialcmte markup congress tn08 fiservices	__label__fiservices __label__congress __label__tn08
+talking lack answers amp faulting obama foreign policy syria amp benghazi 1400wond williams	__label__benghazi __label__syria
+timesunion new york state sees end season surge obamacare signups http cfcyc7f23u aca	__label__aca __label__obamacare
+honored stand lasd sheriff rep janicehahn reproybalallard amp mridleythomas stand gunviolence http wml24kyjao	__label__gunviolence __label__lasd
+marty walsh repmaloney working communities safe	__label__ma
+glad meet senateyouth leaders allison berger madison amp rafael nunez irvington ussyp http q2iihiebiz	__label__ussyp __label__njs
+û÷born free american womanûª teapartybecky gerritson confronts government video http ys4nrvudvw dailycaller irs	__label__irs
+thanks followfriday financialcmte repgarrett repshelley repjohncampbell patrickmchenry	__label__ff __label__followfriday
+photo repandrecarson west indy community day congress corner http k4xs8uqgxe	__label__indy
+enjoyed kielbasa stuffed cabbage ethnicday carteret danreiman elected officials http hpy3927jbt	__label__ethnicday __label__carteret
+met folks standingrock today talk plan boost native tourism northdakota http kgfxkyztqu	__label__native __label__northdakota __label__standingrock
+congrats laughlinafb air force bases reducing energy consumption quarters usaf delrio laughlinafb	__label__1 __label__delrio __label__usaf __label__laughlinafb
+ohioans vote today despite gopshutdown courts year including supreme court http 938y5uk8gg	__label__gopshutdown
+touring damage recent tornado watfordcity amp discussing coordinated response disaster preparedness http mf7i0k44ck	__label__watfordcity
+glitch creates world trillionaire obamacare û÷glitchesûª trillion new debt http smzvb076r1 fail	__label__obamacare __label__fail
+expiration cost economy billion jan feb renewui actonui http w03nf2cj7q http ubotu7gepa	__label__renewui __label__p2 __label__actonui
+voted allow lawsuit president obama congress act defend constitution liberty pjnet http cvytvqakdf	__label__liberty __label__pjnet __label__constitution
+maui tomorrow morning tune kpoa935fm talk story alaka paleka rep tulsi gabbard 30am	__label__maui
+constituent meetings today kingston district office helpful feedback issues ny19	__label__ny19
+veterans day die suicide work ensure vets ptsd amp tbi care deserve stop22aday	__label__stop22aday __label__ptsd __label__tbi
+need clear concise plan isis http i7a2fr0kou	__label__isis
+tune foxnews 8pm interview oreillyfactor gosnell murder trial amp controversies related ppact	__label__gosnell
+npca estimates businesses near national parks losing 30m day theyûªre closed http hbrbdltbum enoughalready	__label__enoughalready
+listen live talkradio1210 dickmorristweet abt helping families mentalhealth crisis act hr3717 http kaksr7ueze	__label__hr3717 __label__mentalhealth
+continue fight protect unborn children counting prolife roe40	__label__prolife __label__roe40
+meps act covered today context forthood http f8pirfrioh thank ntsongas cosponsoring important	__label__forthood
+honored participate wreath laying commemorate fallen wwi suresnes american cemetery dday70 http lbqgxlqwct	__label__dday70
+local small businesses idaho alarmed obamacare idpol http 2lmkzpsftn	__label__obamacare __label__idaho __label__idpol
+guest sotu captain john orosz wounded warrior 101st airborne sot http tmv5rgmwqy	__label__sot __label__sotu
+womanûªs boss zip code shouldnûªt determine access preventive care equality means equal access affordable healthcare wematter	__label__wematter
+instead protecting americans nsa endangered americans bloombergnews nsa knew years heartbleed	__label__nsa
+alexander obama admin ûïsecure border nowû propose plan deal immigration crisis https xzydxuiohu	__label__immigration
+spoke victorville rotary club week http bjwy2tpyhg http fdxo4sobaa	__label__victorville
+proof obamacare bad4jobs schools amp local gov dropping time workers http tsv4npnenw fairnessforall	__label__bad4jobs __label__obamacare __label__fairnessforall
+watch todayûªs tax code complex costly amp time consuming fixourtaxcode cutthecode pjnet http qdepn8xda8	__label__watch __label__tax __label__pjnet __label__cutthecode
+house floor voice harmed consequences aca including 6th generation 110 year business	__label__aca __label__pa __label__house __label__business
+yesterday afternoon visited toured thomas built buses located randolph guilford county line nc02 http 3bja1ytvyj	__label__nc02 __label__randolph
+today speakerboehner named members benghazi select committee confident work help uncover truth	__label__benghazi
+joined senblumenthal connstep uaw today send msg exporting products jobs time bringjobshome	__label__bringjobshome
+davidcicilline speak house floor gopbudget watch live http qeiy2udk13	__label__gopbudget
+welcoming isa students sa2020 trip hoping snow http l7y1ot6cjq	__label__sa2020 __label__isa
+recent crs analysis shows coupling reforms debt limit increase common bipartisan practice http s8bltz77p3 letstalk	__label__letstalk
+obamacare signed years ago today bad law worse errors misinformation amp costly regulations http aszzr9cxbk fullrepeal	__label__fullrepeal __label__obamacare
+israeli military captures hamas manual explaining civilian human shields idf forces http h1h3qmamqq	__label__idf __label__hamas
+icymi talked jmartnyt nytimes story vra ruling amp voter suppression south ncpol http kbgz0xuhj6	__label__vra __label__ncpol
+highered affordable 121 570 oregonians owe average 3676 stafford loans higher rates debt dontdoublemyrate	__label__highered __label__dontdoublemyrate
+release price issues statement oklahoma disaster ncpol oklahoma http 7nbfcmqkbc	__label__ncpol __label__oklahoma
+participate freedomworks amp bloggers nationwide discuss obamacare hurting economy fwroundtable	__label__fwroundtable
+shocking federal law defining guntrafficking crime gratified bipartisan progress important issue	__label__guntrafficking
+sweet corn amp pork chops stick exploreminn prefer cheese curds deep fried pickles mnstatefair	__label__mnstatefair
+great talk earlier tonight thekudlowreport reality budget talks deserve look mandatory spending let math right	__label__budget
+congress extend 911health ûò responders survivors suffer yrs later thehill http ohqtrm49dh	__label__911health
+glad whitehouse raising min wage federal contractors time congress raisethewage americans let	__label__raisethewage __label__congress
+wonder republicans house floor campaign purposes hatch act violation notalawyer	__label__notalawyer
+msnbcûªs edshow night talking state washington check http lmxuhftqub	__label__washington
+reptomrice repdesantis thank cosponsoring stopres joining discussion house floor tonight	__label__stopres
+delighted participate park cities rotary clubûªs fourth july parade tx32 independenceday http ys9y6r2mqg	__label__independenceday __label__tx32
+thanks stewart searcy 000th like facebook http 4qql4kr2 ar2	__label__ar2 __label__searcy
+met mike hammer frm statedept public affairs actualidadradio miami dicussed obama recent trip latam http wav5unj2aw	__label__obamas __label__latam __label__miami
+great meet fast4families discuss timeisnow voice heard http fq8zsqpjej http bsgqmex14m	__label__timeisnow
+craft breweries 847 workers support 917 help small businesses grow illinoisbeer http v63umx4tfs	__label__il
+longer deal costly address actonclimate happyearthday	__label__actonclimate __label__happyearthday
+know americans want raisethewage small business owners agree wematter	__label__raisethewage __label__wematter
+obamacare affecting question implementation tell asksebelius pjnet tcot	__label__tcot __label__asksebelius __label__pjnet
+yrs bradybackgroundchecks kept guns wrong hands time finishthejob amp expand checks http 7rclzwypcd	__label__bradybackgroundchecks __label__finishthejob
+talking fairness amp songwriterequityact today housejudiciary hearing http hytjr7libc	__label__songwriterequityact __label__fairness
+progress good centeronhalsted heartlandhelps affordable housing project lgbt seniors chicago il05 http hr3jam54oh	__label__il05 __label__chicago __label__lgbt
+1010means lifting wages million women amp families raisethewage http k1as13bljw	__label__raisethewage __label__1010means
+hello texas started rptcon14	__label__rptcon14
+support funding help highschool dropouts atriskyouth ged skills turn lives http zxm76lhmt3	__label__highschool __label__atriskyouth __label__ged
+soy1 thank toddrokita great meeting discuss agriculture indiana soybean farmers http 7vw99wyrql	__label__agriculture __label__indiana
+nature florida touring new river ftlcitynews mayor jackseiler amp senwhitehouse kingtide action http v93lib3mfvû	__label__kingtide
+awesome turnout potato head launch food bank grow mobile food bank newhaven	__label__newhaven
+obama doublespeak best said bush43 went congress executive orders denies http 99xoyf3epj	__label__bush43 __label__doublespeak __label__obama
+repdwstweets thank mayor juliancastro making devin dream come true goheat devinsjourney rixyspr http we8c9utsh1	__label__devinsjourney __label__goheat
+huge admission deptvetaffairs plenty evidence data destruction data manipulation criminal	__label__criminal
+applaud usedgov shining light sector hopeful forprofit task force announced provide clarity schools	__label__forprofit
+whatwomenneed valentineûªs day equalpay check video http rsj3lkdk8d	__label__whatwomenneed __label__equalpay
+relieved hear girls kidnapped boko haram escaped captors bringbackourgirls http t1shft0cb4	__label__bringbackourgirls
+senatefloor discuss obamacare amp higher health care premiums watch http 8o4feeho9v	__label__obamacare
+iava combatsuicide	__label__combatsuicide
+benghazi hearing begins today watch live stream beginning http d7t4ih3j6o	__label__benghazi
+ûïthe fog obamacareû washingtonpost today highlights uncertainties obamacare brings smallbiz http moif4lnp8q	__label__smallbiz __label__obamacare
+headed east northport announce solution protect seniors identity theft social security medicare cards	__label__s
+repsusandavis thanks joining san diego innovation economy pushing forward markcaffertysd sdchamber	__label__innovation
+small businesses forced reduce employee hours order comply obamacareûªs mandates http qplrx1zqvg	__label__obamacares
+nominating uconnwbb coach geno auriemma amp uconnmbb kevin ollie als icebucketchallenge hours http muhus9qmsx	__label__icebucketchallenge
+maternity care visits prescriptions amp preventive care covered new health plans tell adult kids gets enroll momknowsbest	__label__momknowsbest
+33k jobs impacted obamacare medical device tax http a4ffzszfqw	__label__obamacare
+president obama amnesty lawless unconstitutional http fl71hciqhc stopobamasamnesty http 963jfr18ba	__label__stopobamasamnesty
+sure tune allinwithchris msnbc 8pm tonight talk latest news	__label__nj
+kickoff gobroncos unitedinorange	__label__gobroncos __label__unitedinorange
+recent grads unable participate economy mountain debt bankonstudents http pxrwwavn7h	__label__p2 __label__bankonstudents
+thank repsinema drawing attention veteran suicide prevention raising awareness stop22aday http hcsvauumuq	__label__stop22aday
+onthisday 1866 president johnson declared american civilwar	__label__civilwar __label__onthisday __label__1866
+thanks support senorrinhatch today nationalpediatricbraincancerawarenessday hope join fighting disease	__label__nationalpediatricbraincancerawarenessday
+obama admin saying enrollees obamacare cnn 114k total state run exchanges watch http fqqefq6hx2	__label__obamacare
+icymi seattle times editorial advocating passage combat sex trafficking notforsale http 6udkvgac9g	__label__notforsale
+day soldiers great service america mankind let neverforget strength courage	__label__neverforget
+thanks greggharper supporting 4351 alzheimer accountability act making priority endalz	__label__endalz
+received 000 petitions everytown supporting commonsense gun reform thx advocacy notonemore http z2ew0psi4j	__label__notonemore
+lottery determine preschoolers stay headstart better time cancelthesequester http 8yhqdfhpyj	__label__cancelthesequester __label__headstart
+ironic president calling bordercrisis problem problem helped create http cu6rlaeqyq	__label__bordercrisis
+washington post finds false sequester claims coming white house http ah5ghrloma	__label__sequester
+todayûªs tax code complex costly time consuming avg taxpayer spends hrs filing cutthecode	__label__cutthecode
+new cms report shows obamacare leaving million americans higher premiums repealobamacare http pkwdcsjc3g	__label__obamacare __label__repealobamacare
+opening stmt psi hearing sencarllevin wall street bank involvement physical commodities http uxgw8zys8q	__label__psi
+admin working cut medicareadvantage seniors http c8m41eql3c working options http 5zs7zzweuu nv03	__label__medicareadvantage __label__nv03
+sent letter speakerboehner urging vote cir amp begin address humanitarian crisis border http ibbafoiz2o	__label__cir
+yrs ago today martin luther king spoke dream dream continue stride equality http h7tgmrs6d4	__label__equality
+national citizenship day aapis want immigration reform family reunification path citizenship aapis4cir	__label__aapis4cir
+americans deserve notch standard health coverage matter work notmybossbusiness hobbylobby http 6wzmk7mpsb	__label__notmybossbusiness __label__hobbylobby
+saveourmilitarycommissaries amendment included funding passed house http oafliryete	__label__saveourmilitarycommissaries
+typical snap household kids income roughly 000 family endhungernow	__label__snap __label__endhungernow
+chance hearing fosteryouth involved sextrafficking watch http 1evpbqmcmr	__label__sextrafficking __label__fosteryouth
+hope today illinois joins growing list states allowing couples opportunity share love amp commitment marriage il4m	__label__il4m
+new study confirms fears obamacare harmful cuts medicare advantage study http oldszdkjcq	__label__obamacare
+million veterans received mental health treatment 2012 million outpatient mental health visits year	__label__veterans
+check bostonglobe story umasslowell amp natick labs partnership gen innovation leaders ma03 http omeduzu9	__label__ma03 __label__natick
+pleased barackobama acting raisethewage federal contract workers isn time million americans	__label__raisethewage
+reptimgriffin watch nancypelosi refuse negotiate debt ceiling claim ûïthereûªs cuts makeû http 570cohnfys neû	__label__ne
+visited laspositas students town leadership conference future amp good hands ca15 http aoxdry0thd	__label__ca15
+marine corps commander hold commanders accountable mstreforms http ql5f1jwe6o	__label__mstreforms
+congratulations corningchamber happy 100th anniversary ny23 http r5txptquhu	__label__ny23
+supporter school choice proud vote qualitycharters act strengthen charter school programs http l5g11frp3q	__label__qualitycharters
+thanks shale boom gas prices dropping nation yes2energy housecommerce http jtngea2chx	__label__yes2energy
+congratulations warf news innovation award winners moving madeinwi science research forward http 7wqasus7hn	__label__forward __label__madeinwi
+joe voted vawa need stand survivors domestic violence sexual assault stalking	__label__vawa
+allow default amp shouldn play games countryûªs economy credit rating http wu574ogf hoyerheadlines	__label__hoyerheadlines
+mtg press said look forward hearing sotu tonight amp presidentûªs message opportunity optimism action	__label__sotu
+taken long cloture invoked package renewui hurdle path final passage	__label__renewui
+great morning celebrating apsu stop clarksville downtown market perfect fall like day tn7	__label__tn7
+obamacare fundamentally flawed itûªs clear isn ready prime time delayed amp repealed http dofkq2v4cp	__label__obamacare
+stateofcivilrights hearing urged support death custody reporting act iûªm pleased senate passed important	__label__stateofcivilrights
+jimlaubler read efforts ensure potus upholds constitutional responsibility latest newsletter http qmuzuz0fnt	__label__potus
+single parent kids making min wage amp working time family lives poverty raisethewage http gcvsfqhvco	__label__raisethewage
+yes shout edgewater park twp adrianabellini8 small town called edgewater park twp burlington sundayjerseyshoutout	__label__sundayjerseyshoutout
+continue push change reform police departments nation ericgarner blacklivermatter	__label__ericgarner __label__blacklivermatter
+julia hartz founder eventbrite telling story readysetsucceed http k2sgdc8pn7	__label__readysetsucceed
+india free clinic 20th year delivering quality health care need mepolitics http zknvjsfczn	__label__mepolitics
+read repgoodlatte thehill today internet access tax ban permanent http ytftkfj48h pitfa	__label__pitfa
+defunds obamacare whasnews sen mcconnell urges passage house continuing resolution http ylucnqnzke whasnews	__label__obamacare
+taxextenders amdt filed generate cleaner air amp american jobs extending investment tax credit offshore wind	__label__taxextenders __label__wind __label__jobs
+liberalism vegas school thinks sexed year olds	__label__liberalism
+conyers amash libert act stopgovtabuse 4thamendment rights rep cosponsor http u9jvgpawl0	__label__stopgovtabuse __label__4thamendment
+icymi wkbn efforts help delphi retirees http gi039nfpck	__label__delphi
+remember innocent died reckless gun violence silent honorwithaction http noo4urvztm	__label__honorwithaction
+juleshastweets especially honored support vawa	__label__vawa
+proud join colleagues end workplace discrimination lgbt federal workers enda lgbteqcaucus http mhtisajzdy	__label__enda __label__lgbt
+america uninsured rate dropped lowest 2008 acaworks	__label__acaworks
+million hardworking americans benefit housegop joins dems raisethewage let http dr0wkw9yqm	__label__raisethewage
+stories like jason proud support defend obamacare read story soon jason http aroogvx9wo	__label__obamacare
+jessicabowser1 rode gerry connolly trail mapmyride http cucrnywqlu cycling bike	__label__bike __label__cycling
+joined students southeastern college coffee let know visiting http 9uvrslxkvl http kbou78e4ul	__label__il
+nokxl presser eastern rayburn 2456 janschakowsky erichpica mauracowley public citizen keystonexl keystone green	__label__green __label__nokxl __label__keystonexl __label__keystone
+grateful soundregion consideration transportation funding 530slide recovery http efdtttrkhv	__label__530slide
+boehner kills foia improvements nielslesniewski day headed president cspanwj	__label__foia
+speaking dan klein wibg1020 ocean city house gop leadership denying vote hurricane sandy aid southjersey	__label__southjersey __label__sandy
+obamanomics higher taxes lower consumer spending slow economic growth http 1c6dv7kzq4	__label__obamanomics
+record nmdrought provide relief farmbill renews disaster assistance programs makes retroactive glad got	__label__farmbill __label__nmdrought
+hobbylobby decision victory amendment rights read statement http trea6d2c5y	__label__hobbylobby
+proud support farmbill restores certainty farmers amp moves past pelosiûªs costly big government policies http lq6k8kesch	__label__farmbill
+getting ready sit woody tasch greg fischer hero wendell berry slowmoney14 watch https qljutme044	__label__slowmoney14
+share seafood got chance prove mdtrueblue crabcakes regional delicacy http 0py39mygqs	__label__crabcakes __label__mdtrueblue
+housejuddems rollingstone new coalition emerges nsa surveillance repjustinamash repjohnconyers bring amp httû	__label__nsa
+honored stand support skillsact gopleader repjohnkline repvirginiafoxx today http hsff1uspea	__label__skillsact
+great season opener spurs http js5qslw1wq mysa gospursgo	__label__gospursgo
+texans benefit medicaid expansion expandmedicaidnow http u6kash3iil	__label__expandmedicaidnow
+calling marion county come town hall flippin details http 7bhiazm2ua ar3	__label__ar3
+proud sponsor 2022 protect taxpayers wake irsscandal http xgzurpjkta repdianeblack irs http 2ud1jtkqaw	__label__irsscandal __label__irs
+read statement year anniversary iraq war http zj7725gvfk	__label__iraq
+stjudegovoffice marshablackburn thanks support alyssa patients jude fad13 chgme http gjû	__label__fad13 __label__chgme
+proud fight hatred ajcgov thank repsteveisrael opposing asa decision boycott israeli academic institutions	__label__asa
+today momsequalpay day day 2014 working moms catch working dads earned 2013 equalpay paycheckfairnessact	__label__equalpay __label__paycheckfairnessact __label__momsequalpay
+looking forward discussion aca jim bohannon nepa tune 840am 960am 1200am	__label__aca
+fha added gao list high risk govt programs http tlzjgwjf	__label__fha
+believe taxpayers deserve know obama admin spending money http 1s7u3z7klo obamacare serco	__label__serco __label__obamacare
+audited irs based political ideology share story http w2o7toecot	__label__irs
+icymi responded wsj recent editorial grand theft disability highlighting management ssdi program http ppk8omo3xd	__label__icymi
+today 13th anniversary september11 terror attacks moment silence pray amp remember forget god bless america	__label__september11 __label__america
+sen murray joins corybooker intro abc act http p7uif0gfk2 abc123 http vojadqagod	__label__abc123
+iûªm taking stand bullying wear purple profile pic purple spiritday http xfz1ytmivw lgbt	__label__spiritday __label__lgbt
+broad bipartisan support bluealert grahamblog senatorleahy way like amber alert let public involved safety	__label__bluealert
+joyce bat house let porch notthefirsttime onlyinaz azliving http hk44rjx4km	__label__onlyinaz __label__notthefirsttime __label__azliving
+chris holbert stopinyumafirst	__label__stopinyumafirst
+join healthequity supporters twitter storm heaa2014 today 3pm	__label__heaa2014 __label__healthequity
+getting started fannin county town hall tonight folks aren happy stacksofbills http edggknonhe	__label__stacksofbills
+chiefs announced monday safety eric berry hodgkin lymphoma good news considered highly curable http bym1jezyny	__label__chiefs
+agree chasing higher spending higher taxes sacrifice growth chairman reppaulryan today hearing gop	__label__gop
+tomorrow intl womensday inventors olympians upstate home outstanding women ny22 http vv0yo6f43g	__label__ny22
+ahora vivo foxnews hablar sobre acuerdo nuclear iran implicaciones seguridad nacional eeuu aliados shannonbream anhqdc	__label__iran
+questioning atf director watch http an4efgrtep	__label__atf
+jaredpolis introduced protect lgbt students frm harassment discrimination cong support snda http lc0xelizo4	__label__snda __label__lgbt
+veteransday remember honor brave veterans sacrificed nation az05 http uzwlzwm4y5	__label__az05 __label__veteransday
+american voters support delay obamacare individual mandate http abqx0pvguo	__label__obamacares
+merry christmas entire latta family family oh5	__label__oh5 __label__christmas
+incredible morning standing icons feminist movement watch video eranow rally scotus http o9ca1083yj	__label__eranow __label__scotus
+gregakagi fri issues pgm 6am 580wibw senpatroberts kelly guest look weeks farmbill discussion	__label__farmbill __label__580wibw
+mlive muskegon manufacturer planning million expansion creating new jobs http pu8z6ctm6z mi4jobs wioa	__label__wioa __label__mi4jobs
+todayûªs sked http gxhskkwdfq house voting senate passed vawa stopthesequester	__label__vawa __label__stopthesequester
+great friend andrea mitchell mitchellreports honored work cancerawareness today http iofvkr8mmo	__label__cancerawareness
+happy fathersday great day enjoy blessing family http qyh1vuc5jg	__label__fathersday
+thanks repjohnkline cosponsoring 2453 help seniors medicareadvantage doctors	__label__medicareadvantage
+communities wait usatoday makes clear moral obligation address climatechange http hg24u7nntl	__label__climatechange
+majority small business owners like agree congress raisethewage http zcpw50wya6	__label__raisethewage
+ppl spend nice dinner earning minimum wage meals livethewage	__label__livethewage
+cleveland clinic cutting budget increased costs obamacare trainwreck http jvcu9omefa	__label__obamacare __label__trainwreck
+todayûªs commerce committee field hearing streamed live online starting 30pm http s3ilh144	__label__wv
+families money federal government means freedom plain simple cpac2013	__label__cpac2013
+weds district staff hold office hours fallriver stop 318 city hall share concerns ma4	__label__fallriver __label__ma4
+kudos mark levin admonishing reilly http byausrkvem marklevinshow oreillyfactor tcot	__label__tcot
+awful standing solidarity carolynbmaloney lawmakers working hard stem gunviolence huffpostpol http kieon407v9	__label__gunviolence
+tbt whitehouse president billclinton http zfyp6gv37u	__label__tbt __label__billclinton
+schultz radio talk california drought amp infrastructure listen http gbus939i7r cawater	__label__infrastructure __label__cawater __label__drought
+special thank utility line workers amp employees working clock restore power https ymrouklahj vtpoli	__label__vtpoli
+hope happymothersday http zdgcnoldr7	__label__happymothersday
+thank hosting briefing discuss need shelter services child sex trafficking victims sharedhope ecpatusa dmstr	__label__dmstr
+eliminating fed redtape medicaid reform allows states save innovate http hpf83tdu	__label__medicaid __label__redtape
+special congratulations volunteers honored unitedwaycle amazing job uwcle oh16	__label__uwcle __label__oh16
+today news sen bernie sanders http uu93fzjdy0 vermont kochbrothers studentloans	__label__studentloans __label__vermont __label__vt __label__kochbrothers
+heading floor talk senate confirm vivek murthy topdocnow watch live http sdruxtpo1g	__label__topdocnow
+farmbill continues strong cost sugar policy supports 27k jobs amp nearly economic activity louisiana	__label__farmbill __label__louisiana
+join praying country today nationaldayofprayer	__label__nationaldayofprayer
+tune womensucceed twitter tweet thon dems congress	__label__womensucceed
+best wishes usparalympics athletes especially ûòtb teamusa http ydzwa797pp	__label__teamusa __label__wi
+god bless serve arkansas runforthefallen littlerock ar2 veterans http 63hengbztq	__label__arkansas __label__veterans __label__ar2 __label__littlerock __label__runforthefallen
+thanks bravery greatest generation tyranny defeated freedom rings today dday70 http kzjg7lpcww	__label__dday70
+looking forward day mo8 farm tour visiting deer farm pig farm grocery store farm table	__label__3 __label__mo8
+usdanutrition miss usdaf2s chat today tell bring farm school follow healthierneû	__label__usdaf2s __label__healthierne
+thanks protectnevada lvlcc lasvegascyclery resort assoc lushltd hhughes letter goldbutte http gstx5mzji7	__label__goldbutte
+great day today bringing bona fide ûïhurricane hunterû schools woodland park wayne nutley verona scienceinaction	__label__scienceinaction
+mannytmoto gr8 having thank showing texans amp americans secure quality affordable health care aca	__label__aca
+finished tour boeing facility charleston great company great employees great airplane boeing787	__label__boeing787
+happening sen sanders msnbc talking chrislhayes veterans medical	__label__veterans __label__msnbc
+radio free europe barred azerbaijan convention old obama gang good http dlmhakgul3	__label__azerbaijan
+house gop voted deny millions americans access healthcare amp pushed closer govûªt shutdown shameful	__label__shameful __label__gop
+prayers parents trayvonmartin demonstrated extraordinary courage awful tragedy	__label__trayvonmartin
+murray partisan house cut current level gut transportation amp housing cut rental assistance veterans	__label__transportation __label__veterans __label__housing
+house voted delay obamacare mandate tax rest year	__label__obamacare
+earthday born usa amp observed globe great legacy continuing stewardship	__label__earthday
+congratulations robin kelly winning il02 night progressive woman halls congress offthesidelines robin42cd	__label__il02 __label__offthesidelines
+great dailyorange post point opportunityplan help working families thrive 21st century economy http 8xosg54wui	__label__opportunityplan
+great floridians visiting nation capitol aipac2013 policy conference sayfie http wgznnizosw	__label__sayfie __label__aipac2013
+want congratulate harmony school celebrate stem education discovery day hosting http 82hwagpxpr	__label__stem
+discussing affects sequester indiancountry senate indiancommittee hearing watch live http 1d54cweh04	__label__indiancountry
+week pass uncontroversial helium reserve pretty light work heh heh heliumreservejokes	__label__heliumreservejokes
+cbo finds obamacare lead fewer time employees reformhealthcare	__label__reformhealthcare
+mayortommenino thank tireless advocate safety children amp communities theydeserveavote	__label__theydeserveavote
+ûï kiyomit1 moved stories jobseekers told repdelbene today trials job search liveonkomo http ejm6vneafrû	__label__liveonkomo
+talked alexis rising star involved neastudents student loan debt inspiration degreesnotdebt http 7okwfujxqx	__label__degreesnotdebt
+thankful opportunity represent conservative mississippi values washington http j1q9ps9w9h http ptff1b1ubk	__label__thankful __label__mississippi
+catch ajam 2night talking need funding gun violence research endgunviolence	__label__endgunviolence
+icymi video witnesses confirm uncertainty definition medical device http scsp3usyjj obamacare	__label__obamacare
+great news largest employers bluediamond reporting record revenue growth http waeql7dxct ca07 icymi	__label__icymi __label__ca07
+important item trade exports list reauthorize eximbankus prochat	__label__prochat __label__trade __label__exports
+1billionrising rallies helping explain imp vawa amp house priority senate passing week	__label__1billionrising __label__vawa
+showsomelove valentinesday gop congressional delegation howardcoble patrickmchenry repwalterjones virginiafoxx	__label__valentinesday __label__ff __label__showsomelove
+thanks martin dempsey welcoming sotu guest night keesler afb airman msgt becky patterson http v0zwv93lbu	__label__sotu
+proud rochesterûªs wegmans fortunemagazine list 100 best companies work http oacc3j6lmx	__label__12
+little years ago 1st pres obama signed law lilly ledbetter fair pay act dws demwomen	__label__demwomen
+colleagues intro hjres123 require potus present strategic plan congress isis isil	__label__hjres123 __label__isil __label__isis
+coming noon sen sanders cnnsotu talking crowleycnn veterans health care	__label__veterans
+senrandpaul congrats friend corybooker hill beautiful list http 7kjppbe1de	__label__44
+happy national voter registration day celebratenvrd getting registered right http q03caubpdd	__label__celebratenvrd
+bostondotcom senator markey amazon drones need rules http mu8uabc230 mapoli masen	__label__masen __label__mapoli
+5th anniversary time minimum wage raised ncians working hard struggling ends meet raisethewage	__label__raisethewage
+instead putting college reach american students let invest future economy middle class dontdoublemyrate	__label__dontdoublemyrate
+kujua21 plan replaceobamacare http ywxi4u9qgg	__label__replaceobamacare
+house easy senate democrats act jobs http 9c00mcts9f	__label__jobs
+long time coming come keepthepromise veterans watch katctv3 recap http m1wrauqtj5	__label__veterans __label__keepthepromise
+campus life california moved healthier tomorrow uofcalifornia tobacco free policy takes effect nosmoking	__label__nosmoking
+reptomprice 3yrs potus healthcare law enacted ûò remain committed patient centered solutions amp fullrepeal	__label__fullrepeal
+congrats berlin coolest small town america 2014 100 worth visit travelmd beachandbeyond http hcqh5co9of	__label__md __label__berlin
+btnlivebig uofmaryland student bringbackourgirls daily commitment http 2evcncab8p joinrepwilson bringbackourgirls	__label__joinrepwilson __label__bringbackourgirls
+visited fremont wellness center community garden los angeles communitygardens http hxbskfa92k	__label__communitygardens
+pres right years isolation worked need increase people people exchanges cubapolicy	__label__cubapolicy
+president obama mission shutdown coal production need proof http aasbw8clxh waroncoal	__label__waroncoal
+celebrating iaiasantafeûªs yrs cultivating art cultural identity students smithsoniannmai http yhqqb5wfbn	__label__nm
+grahamblog know benghazi result pre planned terrorist attack high level qaeda operatives prû	__label__benghazi
+happy day socialsecurity program helps seniors including million hoosiers yrs http 2dyimrct9l	__label__socialsecurity
+interview michellefields expanding education opportunity schoolchoice http dn1qmi8af5 pjnet	__label__pjnet __label__schoolchoice
+think donated important campaign http http 3bhcey8jf0 thankyou	__label__thankyou
+absurdity mccain criticism potus response ukraine matched utter silence differently	__label__ukraine
+spoke today usda forest service usfs personnel country forestry policy chair agriculture cef subcommittee	__label__forestry __label__usfs __label__agriculture __label__usda
+repmartharoby proud join friends repcorygardner reprichhudson repkevinyoder reptimgriffin amp repmgriffith discuss affû	__label__aff
+abc news reports irs official charge political targeting responsible obamacare office http nox3skduvs	__label__obamacare
+onthisday 150 years ago construction capitol dome completed http rjvjppbcsp	__label__onthisday
+headed town hall meeting northwest phoenix	__label__phoenix
+signed letter hhs sec sebelius asking action savesarah http wkyekaqses	__label__savesarah
+arizona republic mccain plans arizona election fundraiser http rtnzyaasp2	__label__arizona
+wha bethmceldowney sequester repdavid plane pulled wrong gate casualty obamasequester	__label__obamasequester
+navalny conviction takes russia days ussr courts weapon tyranny stmnt senjohnmccain http ipaoyd3hbk	__label__navalny
+today introduced repaysupplies act permanently extend deduction teachers pay pockets supplies	__label__repaysupplies
+ihealthbeat mobihealthnews covered telehealth read http y4cvxb6caw	__label__telehealth
+gives big biz break obamacare trainwreck break individuals amp families http rturokegpg	__label__obamacare __label__trainwreckwhat
+letûªs started ready questions repolicy http pkarx2uoxs	__label__repolicy
+wow got watch ûó12 year old chastises republicans efforts restrict votingrights http hzmeg2fnjj	__label__votingrights
+finished interviewing mortonowh statuary hall sotu http 1xuqi7h0or	__label__sotu
+voted yes hr2 american energy solutions lower costs american jobs act combines pieces energy related legislation previously passed house legislative package seeks expand energy production reduce bureaucratic red tape passed 226 191	__label__hr2
+voted yes rohrabacher amendment hr4660 prohibits funding department justice prevent certain statesûóincluding michiganûófrom implementing state laws authorize use distribution possession cultivation medical marijuana cosponsor amendment amendment nearly identical rep rohrabacher amendment 2012 supported previous vote explanation http facebook com repjustinamash posts 398285686877510 years ago amendment failed 163 262 year amendment agreed 219 189	__label__hr4660
+voted yes ordering previous question closing debate hres575 rule defining process considering hres567 establishes select committee events surrounding 2012 terrorist attack benghazi motion passed 223 192	__label__hres567 __label__hres575
+problem intelligence agencies like nsa violating constitution spying hundreds millions americans probable cause kind hypocrisy biggest reasons public stand congress	__label__nsa
+voted polis amendment title hr3865 amends long title read protect anonymous special interests prohibiting internal revenue service modifying standard determining organization operated exclusively promotion social welfare purposes section 501 internal revenue code 1986 long title meant provide summary purpose scope purpose protect anonymous special interests amendment agreed 177 241	__label__hr3865
+need need increase minimum wage need women equal pay equal work need sure americans lost jobs fault donûªt emergency unemployment benefits counting feet destroyed available donûªt time waste raisethewage renewui timeisnow equalpay	__label__raisethewage __label__renewui __label__equalpay __label__timeisnow
+proud member congressional asian pacific american caucus capac early years seen develop influential voice americaûªs diverse asian american pacific islander aapi communities iûªm pleased join colleagues celebrating 20th anniversary capac look forward capacûªs future success apahm	__label__apahm
+honored veterans northeast veterans day parade today best way gratitude keeping promises americaûªs service members veterans	__label__veterans
+american people like president obama way ahead politicians comes immigrationreform want broken immigration fixed want fixed time shutdown progress good economy good security good american values time action timeisnow	__label__immigrationreform __label__timeisnow
+congratulations jimeca lawrence fort valley state university selected student winners department agriculture 2014 agricultural outlook forum student diversity program	__label__diversity __label__agricultural
+house republicans remain focused growing good paying jobs american workers president obama learn speaker gov jobs	__label__jobs
+pieces congress fix hobbylobby health care notmybossbusiness	__label__notmybossbusiness __label__hobbylobby
+remember promises fullrepeal	__label__fullrepeal
+happy nationalcoffeeday	__label__nationalcoffeeday
+forget escape velocity economy 2014 likely record disappointing year growth growthgap costing millions jobs delta gdp rivals entire economy nations	__label__growthgap
+president determination permanently harm coal industry astounding hurts real people destroys jobs waroncoal	__label__waroncoal
+unexpected fallout obamacare	__label__obamacare
+forget tune fox business stuart varney talk expect hear today acting irs commissioner danny werfel	__label__irs
+37th time house gop vote repeal aca big thanks boehnercare allowing insurance companies place lifetime limit patient health coverage place dollar life time work stop wasting american people time hard earned tax dollars	__label__boehnercare
+senate leaders agreed cosponsor able act giving new hope severely disabled families america able commonsense piece legislation helps parents severely disabled save prepare childûªs lifetime expenses broad bipartisan support houses congress hope 2014 year finally passtheableact	__label__passtheableact
+day delay stillbroken	__label__stillbroken
+today joined sponsors studentloan discuss permanent partisan solution tired issue political football let solve problem	__label__studentloan
+tbt colbertreport taping segment better know district good times watch http thecolbertreport com videos imczen better know district north carolina 1st butterfield	__label__tbt
+obamacare wonderful employers slashing jobs cutting work weeks soften sting fairnessforall	__label__obamacare __label__fairnessforall
+undersecretary hickey explaining utilizing technology better assist veterans reduce backlog	__label__va __label__veterans
+fight protect victims sexual assault military continues hope colleagues senate join sen kirsten gillibrand effort fight men women wear nationûªs uniform like agree victims terrible crimes deserve justice mjia	__label__mjia
+great news gallatin tn06	__label__tn06
+parent educator believe tennessee students deserve possible opportunity succeed today voted support qualitycharters act encourages school choice promoting state efforts develop expand charter schools read http usa gov 1hcxrpv	__label__qualitycharters
+tbt rainy day fall 2011 greeting veterans music city honor flight outside world war memorial special day house passed legislation reopen monuments country yesterday hope senate follow suit http instagram com fbnjrgp	__label__tbt
+happening house foreign affairs committee began hearing state departmentûªs lack accountability aftermath benghazi terrorist attack watch live	__label__benghazi
+great time attending ribbon cutting servpro new facility gallatin saturday expansion create new time jobs sumner county tn06 latergram http instagram com exnsyij	__label__tn06 __label__latergram
+president obama previously described healthcare law new set rules treats everybody honestly treats everybody fairly weeks ago according pres obama big financial institution government contractor comply obamacareûªs mandate year tennessee family trying ends meet taxed add insult injury president gall veto house passed legislation delaying obamacare employer mandate individual mandate veto threat pathetic excuse leadership share like want senate follow house lead president bluff passing common sense bills americans needed relief obamacare trainwreck fairnessforall tbt	__label__tbt __label__fairnessforall __label__trainwreck
+instagram post iûªm busy district work week thanks joined town hall meetings industry tours look forward keeping touch sharing washington home tn06 http instagram com zbvvkxp	__label__tn06
+icymi night marine sgt andrew tahmooressi joined foxûªs record interview released prison mexico 214 days america glad marinefreed	__label__marinefreed
+heart goes families eyalgiladnaftali prayers people israel	__label__eyalgiladnaftali
+happy sacramento kings new partnership legends hospitality continue momentum region farm fork movement productive agriculture regions world partnership help showcase creating jobs region ca07	__label__ca07
+years ago today thousands brave american allied soldiers stormed beaches normandy liberate europe rid world tyranny stand americans remembering honoring sacrifices today dday	__label__dday
+today equal pay day ûò day marks number extra days 2014 average woman work earn male counterpart half workers women percent working women primary breadwinners families theyûªre paid impacts family economic issue ûò womenûªs issue thatûªs iûªm pleased senate considering paycheck fairness act week iûªm strongly supporting help ensure equal pay equal work house needs follow lead delay womensucceed nomadmenpay http bera house gov issues womens equality	__label__nomadmenpay __label__womensucceed
+enjoyed touring intuitive research technology today visiting huntsville businesses engineering defense contractor recently named best medium sized business work fortune magazine learn http www com business index ssf 2014 huntsville engineeri html	__label__1
+alabama agriculture state industry extremely important health economy support policies allow agriculture continue driving productivity job creation al01	__label__al01
+great visit yesterday huntington ingalls industries facility pascagoula mississippi congressman steven palazzo facility supports 000 jobs southwest alabama critical al01	__label__al01 __label__jobs
+proud serve house armed services seapower tactical land air subcommittees assignments able fight protect important shipbuilding jobs district house armed services committee republicans al01 http byrne house gov media center press releases byrne given choice armed services subcommittee assignments joins house	__label__al01
+think barack obama speech immigration	__label__immigration
+senseless targeting innocent civilians stopped unacceptable circumstances thoughts prayers families killed injured jerusalem attack people israel endured far brutal assaults united states continue fight atrocities bring justice commit acts strongest allies partners combating terrorism reaffirm support israelûªs right defend protect people	__label__jerusalem __label__israel
+government azerbaijan arrested leyla yunus director institute peace democracy azerbaijan husband arif yunus charged high treason tax evasion economic crimes charges filed yunusûªs outrageous leyla arif long time supporters people people contact armenia charge espionage absurd urge government azerbaijan drop charges stop coordinated campaign aimed opposition civil society journalists azerbaijan peacefully exercising right freedom speech freedom association	__label__armenia __label__yunuss __label__azerbaijan __label__arif __label__leyla
+scotus got wrong hobbylobby supporting protect womenûªs health corporate interference act legislation restore contraceptive coverage requirement guaranteed acat protect coverage health services employers want impose beliefs employees denying benefits allowing employers force religious beliefs employees guise religious freedom inexplicable supreme court health american women risk opening door private employers looking reason comply law woman uses contraception private decision subject financial veto employer affordable care act guarantees majority women coverage comprehensive preventive health services including contraception imposing additional financial burdens woman employer claims hold certain beliefs contrary law sets dangerous precedent notmybossbusiness	__label__hobbylobby __label__acat __label__notmybossbusiness __label__scotus
+open enrollment 2014 coverage ends today march need health insurance getcoverednow visit healthcare gov 800 318 2596	__label__getcoverednow
+delivered floor speech honor lasalle lancer ohio state football championship watch http bit 1x29zkm lancersrolldeep	__label__lancersrolldeep
+look things cincinnati washington week great weekend oh01 weeklyroundup	__label__oh01 __label__weeklyroundup
+met jdrf southwest chapter discuss challenges living t1d important research underway time cure	__label__t1d
+proud teamusa idahoûªs olympians olympics sochi2014	__label__sochi2014 __label__olympics __label__teamusa __label__idahos
+enjoy chance visit students government public service wrapped great conversation students gooding high school idpol magicvalley	__label__magicvalley __label__idpol
+yesterday honor flight brought group idaho wwii veterans memorials staff welcomed idpol veterans greatestgeneration	__label__veterans __label__wwii __label__idpol __label__greatestgeneration
+dan reed emailed sequester cuts budget big deal askmddems	__label__askmddems
+today 100th birthday civil rights leader rosaparks sat stand today http tdsjptez	__label__rosaparks
+look whatûªs hanging whholidays tree thanks serve esp united states air force 30th space wing vandenberg air force base calif	__label__whholidays
+join tomorrow coffee discussion work prevent future tragedies notonemore	__label__notonemore
+holding irs accountable putting national security watch july actionnewsjax interview lynnseyanjax http tinyurl com k4a6y63	__label__irs
+texas thrives states fail proudtexan	__label__proudtexan
+gdp declined worst drop recession itûªs time senate democrats pass job bills sitting harry reidûªs desk	__label__gdp
+watch hear thoughts president state union sotu	__label__sotu
+unacceptable million jobless americans house passed solutions itûªs time senate votenow	__label__votenow
+cornyn obamaflightdelays phony contrived	__label__obamaflightdelays
+donûªt hear news endometriosis common estimated women girls affected suffer mild severe pain result disease thatûªs proud congressional host worldwide endomarch support fight increase cooperation research educational campaigns health screenings bring quicker diagnosis disease effective treatment ultimately cure endomarch endomarch14 virtualendomarchers	__label__virtualendomarchers __label__endomarch __label__endomarch14
+tx28tips people states packing grills cold weather south texas grill year round safety tips instructions fema	__label__tx28tips __label__fema
+currently house republicans stated record support clean continuing resolution came floor combined 200 democrats votes reach 218 votes needed majority end shutdown hundreds thousands americans work shuttered federal government minutes speaker boehner allow vote floor clean continuing resolution demandavote end gopshutdown http www washingtonpost com blogs fix 2013 government shutdown end today cost john boehners speakership	__label__gopshutdown __label__demandavote
+new york times series failed warondrugs majority americans believe war marijuana failed itûªs time end	__label__warondrugs
+thanks uconn menûªs basketball victory florida saturday rep wasserman schultz owes burritos gohuskies bleedblue	__label__bleedblue __label__gohuskies
+today celebrate earthday day reaffirm commitment clean safe healthy environment children future generations http usa gov 1txsb8l	__label__earthday
+time years position pass budget agreement strong bipartisan support house senate perfect happy agreement year filled far partisan fighting compromise important step forward programs help create jobs pennsylvania community development block grants nih medical research likely face fewer cuts deal addition overall deficit reduction approximately billion higher agreement allow avoid damaging government shutdown hopeful measure pass senate spirit bipartisanship continue year budget	__label__budget
+informed access quality care prevents disease protects health thank wilmington urban league hosting important forum health wellness allowing participate netde	__label__netde
+happy ar1 staff woodruff electric grand opening event forrest city facility today	__label__ar1
+enjoyed chatting cain agra shep bickley ar1 grain loading facility lake village	__label__ar1
+north schuylkill eighth grader devina singh advanced round scripps national spelling bee preliminaries today correctly spelling romaji watch round espn3 spellingbee	__label__spellingbee
+bipartisan vote senate passed delay sharp increases floodinsurance rates millions property owners coastal flood prone areas order relief reach people hurting house leadership bring measure vote joined 180 members supporting delay today iûªm calling speaker boehner bring vote	__label__floodinsurance
+got talk earlier today special local effort endtrafficking	__label__endtrafficking
+father grandfather understand important secure best care children night voted child care development block grant 2014 early childhood care accessible affordable families setting higher standards safety training child care personnel millions parents rest easy knowing children receiving childcare safer better	__label__childhood __label__children __label__father __label__families __label__grandfather
+important information veterans shutdown impacts veterans services http usa gov 178lgt8	__label__shutdown
+start special order cirmeansjobs	__label__cirmeansjobs
+senators voted internet sales tax year defeated retiring lame duck session best chance pass nonettax	__label__nonettax
+wrong doctor helped catch osama locked bodyguard cleared release gitmo	__label__gitmo
+fact obamacare millions seniors face higher premiums dontfundit defundobamacare	__label__defundobamacare __label__dontfundit
+wishing family happy safe independence day july4th	__label__july4th
+join rosa celebrating women equality day twitter storm use wematter share issues affect women families life	__label__wematter
+tbt march opportunity visit ukraine senate colleagues amid mounting russian aggression eastern ukraine pictured maidan square paying respects lost peaceful protests greater freedoms happened united states position ûò ûò unwavering support ukrainian people sovereignty	__label__tbt
+students deserve chance achieve america dream saddled debt bankonstudents	__label__bankonstudents
+1010means million veterans pay increase let thank service raisethewage	__label__raisethewage __label__1010means
+glad president added line women succeed america succeeds request meeting valerie jarrett monday night sotu	__label__sotu
+bring enda vote house passenda	__label__passenda
+share goodnews friends close seven decades rich birs year old resident portage finally received purple heart earned battle okinawa world war	__label__goodnews
+operation chokepoint administration backdoor initiative shutdown law abiding gun dealers happening right central wisconsin thank hawkins guns llc exposing liberal scheme 2ndamendment	__label__2ndamendment
+tbt summer interns leaving end week thanks gabe stacy seth david hard work summerû forget best intern recruitment video	__label__tbt
+intern wisconsinwednesday	__label__wisconsinwednesday
+people like denise need transplant isn politics frightened belief won coverage needs kilmeadeandfriends keepyourplan	__label__keepyourplan
+630 active road transit projects state slowed stopped congress acts fund highwaytrustfund immediately	__label__highwaytrustfund
+senate passing comprehensive immigration reform major step forward urge house comprehensive reform timeisnow	__label__timeisnow
+christopher palatka health care plan worked family obamacare purchase higher cost plan exchanges face penalty fl06	__label__fl06 __label__obamacare
+president said like plan period unfortunately millions americans turned untrue case missed action news jacksonville reported night introduced allow keepyourplan watch interview	__label__keepyourplan
+today joined senator ted cruz senator rand paul congressman steve daines congressman thomas massie representative john fleming press conference opposition internet sales tax legislation hurts florida consumers small businesses furthermore trust federal internal revenue service earth want subject florida businesses revenue collectors california illinois read http bit 13yptvs nonettax	__label__nonettax
+term draws close tbt day sworn congress 2013 looking forward advocating neighbors term	__label__tbt
+thanks sharing concerns met residents counties wyoming summer fall iûªm going visit businesses state learn need wyoworkstour	__label__wyoworkstour
+cost living continues rise percent americans saying spending groceries year learn house republicans americansolutions help families http www gop gov solutions	__label__americansolutions
+day day samfarrchallenge beginning healthier year extend end year walking wonderful challenge days 000 steps days way low 000 difference hardest bed time snacks course ice cream completely limit alcohol wasn problem occasionally hard late dinner friends limited glasses red wine rest evening drank water weight fluctuated challenge lost gained past weeks thankfully overall net loss going try lose lbs year thank kind notes challenge helped going lap course want thank mary inspiring challenge helpful hints better informed consequences food eat finally congratulations completed challenge lot fun group hope feel healthier able town halls love hear success stories feel free share	__label__samfarrchallenge
+great info robert wood johnson foundation need saveschoollunch check	__label__saveschoollunch
+today look remembering horror thousands american lives lost feeling world changed forever ask towers fell remember nation came stood accord spoke voice world changed day america nation god indivisible god bless united states america neverforget	__label__neverforget
+support actions taken administration free sergeant bowe bergdahl	__label__bergdahl
+sent attorney general holder letter yesterday calling appoint unbiased official lead investigation irs targeting non profit organizations confirmed year read letter http ug3ru justice requires unbiased nonpartisan investigation place hold responsible accountable actions ensure credibility process final outcome like agree	__label__investigation __label__irs
+americans shouldn work government close year taxfreedomday	__label__taxfreedomday
+big shout cbwest girls soccer team bringing home piaa class aaa state championship	__label__cbwest
+fbi ûò federal bureau investigation cross county viii operation rescued 168 children humantrafficking ûó young years old having reported missing trafficking real problem thankfully dedicated coalition local volunteers professionals law enforcement lawmakers working address learn working http fitzpatrick house gov endtrafficking	__label__humantrafficking
+looking memorialday weekend check list events going district	__label__memorialday
+nice work bcths students particpated skillsusa competition america economy needs new generation skilled workers play important role manufacturing energy engineering	__label__energy __label__manufacturing __label__engineering __label__bcths
+best wishes dancers volunteers families kids participating thon14 thon largest student run philanthropy world raised 101 million support diamonds fund hershey childrenûªs hospital right pennsylvania watch live http bit 1dev9io ftk weare	__label__thon14 __label__weare __label__ftk
+week newsletter pa8 olympic connections thought president annual address sotu experience year round read http bit 1ggom8f	__label__sotu __label__pa8s
+house majority leader eric cantor penned oped todayûªs washington post worth read like iûªve saying operating divided government requires sides willing come table negotiate order country forward time start conversations needed reopen doors government address budget restore faith american people simply letstalk read http wapo 1e7cen1	__label__letstalk
+republicans said today taking snap farm getting rid extraneous tell million hungry americans	__label__extraneoustell
+thanks womenunitedfor proud forum gun violence prevention afford silent wu4	__label__wu4
+mentioned today wjbo louisianians oppose obamacare	__label__obamacare
+know house republicans passed dozens jobs bills help create good paying american jobs including legislation secure american energy independence reform job training programs grow economy stuck stackofbills senator harry reid desk fail	__label__fail __label__stackofbills
+congratulations town broadway named safest city virginia va06	__label__va06
+police identified aaron alexis ûò ties fort worth ûò shooting suspect yesterdayûªs navy yard massacre authorities asking information suspect contact fbiûªs washington field office 202 278 2000 800 fbi 800 225 5324 navyyardshooting	__label__navyyardshooting
+important message congressman gutierrez president immigration accountability executive action	__label__immigration
+congresista luis gutiì©rrez acerca reformamigratoria ûïo actì¼an los republicanos actì¼a presidente û vea entrevista jorge ramos ayer punto	__label__reformamigratoria
+light major recent data breaches affecting million target customers possible think happen obamacare website ready primetime supported commonsense legislation house today require federal government notify individuals hours personal information stolen unlawfully accessed obamacare exchange health exchange security transparency act passed bipartisan 291 122 vote help protect americans personal information	__label__obamacare
+good faith vote provides funding obamacare	__label__obamacare
+life looking job better job office helping job fair happening tomorrow yubacity bring resume dress success practice short interview speech	__label__yubacity
+today davis enterprise newspaper published syria response column published paper couple weeks ago lot good questions wisdom potential strike syria lot disconcerting answers	__label__syria
+today 60th anniversary korean war armistice owe enormous gratitude served fought communist aggression know koreanwar veteran post photo honor ûò itûªs small meaningful gesture bring attention ûïforgotten war û office caseworker brandon thompson working harold griffith korean war veteran yuba city try help receive benefits read griffith experiences appeal democrat article http bit 11kl4cp know lives 3rd district encounters difficulty federal benefits district offices week ask constituent caseworker phone number davis office 530 753 5301 yuba city 530 329 8865 fairfield 707 438 1822 sure resident 3rd district http www house gov representatives	__label__koreanwar
+listen conversation schultz issue northern california america today jobs listen radio program link	__label__1
+thanks kendra dallas stewarts duluth visiting office today georgia	__label__georgia
+holiday obamacare delay makes wonder president obama christmas http www politico com story 2013 online shop enrollment delayed year 100438 html	__label__obamacare
+fox news 1pm today talk efforts government open harry reid job negotiate letstalk	__label__letstalk
+sure watch abc week morning great segment efforts government open protect working americans obamacare local times link http abcnews com thisweek	__label__obamacare
+join rep larry bucshon wednesday 00pm transportation infrastructure committee facebook page live question answer session experience driverless car	__label__driverless
+weeks wastewednesday washington times earlier month government accountability office gao testified congress federal agencies 100 billion improper payments year number perspective 100 billion combined total budgets coast guard immigration customs enforcement agency border patrol secret service federal emergency management agency ûó lot click link read http washingtontimes com news 2014 jul chougule unfathomable billions government waste	__label__wastewednesday
+join celebrating best buddies international ûïiûªm hire dayû people special needs skilled productive employable fought pass americans disabilities act continue work sure american businesses inclusive ûïshareû ûïlikeû support inclusive workplace people intellectual developmental disabilities imintohire	__label__imintohire
+iåêam proud mother raised supported family internment san jose strawberry sharecropper able provide siblings opportunities imagined modern complex world raising family requires whatmothersneed today support toåêachieve things families equalpay affordablechildcare paidsickdays paidfamilyleave tbt	__label__whatmothersneed __label__tbt __label__affordablechildcare __label__paidsickdays __label__paidfamilyleave __label__equalpay
+reno david wise wins gold sochi2014 teamusa battleborn homemeansnevada	__label__sochi2014 __label__battleborn __label__teamusa __label__homemeansnevada
+reason holidays new mexico canûªt beat choose skiing powder taos tanning powdered gypsum white sands	__label__5
+marineheldinmexico mexican embassy today support andrew share post 202 728 1600 requests close case andrew favor filed hope final judgement day	__label__marineheldinmexico
+considering inter country adoption check http lba18kjnqu nam13	__label__nam13
+good best luck matthewbagwill pretty awsome rephartzler office inspired	__label__inspired
+mo04fieldreps visiting california nutrition center rephartzler	__label__cj __label__zb
+click link latest update work behalf nv03 included thoughts house passed border reform forget read end tweet posted president signed kids law	__label__nv03
+october house working fund key portions federal government unfortunately bills rejected senate received veto threat white house saying letstalk like share agree	__label__letstalk
+house debate timetobuild keystone pipeline started follow clicking link http www span org live video span think build pipeline	__label__timetobuild
+kids adults donûªt sense dumping awful nutritionnannies lunches thanksmicheleobama http goo ouum0y	__label__ __label__thanksmicheleobama
+looks like nyt admits obamascare fraud day late billions short http goo 2ml102	__label__obamascare
+deptvetaffairs employes cut pasted notes 1241 patient records person employed reformnow	__label__reformnow
+deptvetaffairs allowed veterans die marked care nolongernecessary appear discharged deadheroes	__label__veterans __label__deadheroes __label__nolongernecessary
+court rules impose radical anti conscience hhs mandate ewtn tyranny http goo ur9hkr	__label__tyranny
+obummereconomy fastfoodrecovery worst great depression http goo vyhhl2	__label__obummereconomy __label__fastfoodrecovery
+4th obamacare signups face higher premiums obamascare http goo dsdjqc	__label__obamascare
+king obama entitlement kingdom comes expensive strings attached http goo vgyu6l	__label__entitlement __label__kingdom
+trying blackfriday deals forget tomorrow small business saturday small businesses play important role economy vital communities remember shopsmall support west michigan small businesses smallbizsaturday	__label__shopsmall __label__blackfriday __label__smallbizsaturday
+great 41st president george bush living life fullest 90th birthday happybirthday41	__label__happybirthday41
+chocolate nice women need valentine day equal pay whatwomenneed	__label__whatwomenneed
+nc08 privileged home female chamber commerce presidents ûò women leading way communities helping cultivate environment businesses succeed create jobs panel chamber presidents nc08 women symposium provided insight professional backgrounds experiences discussed issues facing small businesses region today	__label__nc08
+approving keystonexl create 000 jobs lower energy prices home itûªs time build http www bloomberg com news 2014 keystone report said likely disappoint pipeline foes html mod djemmer	__label__keystonexl
+welcome home marine mef returned home helmand province afghanistan militarymonday	__label__militarymonday
+honor fallen memorialday	__label__memorialday
+week militarymonday photo comes capt porter jones usmc congressional fellow office cobra pilot big thanks capt jones photo service semper	__label__militarymonday
+tbt taking nofilter throwbackthursday	__label__tbt __label__throwbackthursday __label__nofilter
+spent minutes morning camp pendleton marines sgt sheena adams sgt chad adams	__label__marines
+yarmulke time hanukkah chag sameach friends fellow new yorkers celebrating night hanukkah	__label__hanukkah
+cbo bipartisan comprehensive immigrationreform legislation house reduce deficit 900 bil decades	__label__immigrationreform
+sweet reasons getcoverednow nearly uninsured americans sign 100 month http gprtwozq7r	__label__getcoverednow __label__7
+improving outcomes experiences minority women breastcancer builds mission encourage minority women demanding careers working capitol hill learn warning signs importance early detection breast cancer save lives	__label__breastcancer
+good morning texas today national minimum wage day support fellow party members work raisethewage	__label__raisethewage
+texas democrats united end gopshutdown	__label__gopshutdown
+womenûªshistorymonth moment day sandra day oûªconnor born paso texas march 1930 mrs oûªconnor grew arizona later attended stanford university 1950 earning bachelorûªs degree economics graduating attended universityûªs law school received degree 1952 time opportunities women law field mrs oûªconnor struggled work able work county attorney californiaûªs san mateo county free soon deputy county attorney 1965 1969 served stateûªs assistant attorney general 1969 state senator filling vacancy won election twice 1979 selected serve stateûªs court appeals 1981 president ronald reagan nominated associate justice supreme court received unanimous approval senate mrs oûªconnor history woman justice serve supreme court married john jay oûªconnor 1952 sons stepped bench january 2006 spend time husband suffered alzheimerûªs died 2009 year president obama honored presidential medal freedom	__label__womenshistorymonth
+looking forward helping lead new state medicaid expansion caucus rep butterfield http huff 1rdhxsh expandmedicaidnow	__label__expandmedicaidnow
+today passed favorably ways means committee expand update child tax credit share believe economy succeeds familiessucceed	__label__familiessucceed
+congratulations downtown mantua revitalizationûªs art hill winning best art cultural event annual portage county celebration oh14	__label__oh14
+great pride bridge builder parties common ground legislation divide look yearinreview ways reached aisle 2014	__label__yearinreview
+share join wishing megan bozek team usa women hockey good luck playoff game tomorrow track illinois olympians http bit olympics	__label__illinois
+nuclear weapons capable iran presents grave threat national security united states allies coming weeks work colleagues senate pass bipartisan iran sanctions legislation soon possible	__label__iran
+wmicentral com ran item today az01atwork tour visit eagar sawmill contributing local economy white mountains	__label__az01atwork
+week stop government abuse week house representatives colleagues extremely bringing accountability washington restoring americans trust government days high ranking federal officials irs getting away betraying public trust paid taxpayer funded vacations brought permanent end real world negligence law breaking consequences time reckless government employees play rules hardworking americans outside washington fund paychecks government employee accountability gea act major steps taking accomplish read gea act pittsburgh tribune review http triblive com opinion featuredcommentary 4382278 government washington trust citizen sponsor gea act https www cosponsor gov details hr2579 113 coverage gea act http online wsj com article sb10001424127887324564704578629623532032726 html http www newsmax com politics kelly irs lerner 2013 517587 follow conversation twitter hashtage restoretrust	__label__restoretrust
+visited national weather service installation taunton discuss climate change impact rivers 4th district increased rainfall extreme weather	__label__taunton
+applaud senate passing month extension unemployment insurance nearly million americans bipartisan vote calling house held roundtable discussion workers region social service providers discuss unemployment insurance importance extending program signed letter speaker boehner requesting vote unemployment insurance extending emergency unemployment insurance important washington state families nearly 000 people state lost insurance end december congress failed provide extension time extendui	__label__extendui
+mary ann strock immigration reform provide ice agents fewer ice agents entire lapd police officers 5000 ice agents enforce immigration laws fix immigration problem ignore rest immigration reform passed senate includes biggest investment border security funding history double size border patrol require additional 350 miles fencing mexico border asktim	__label__asktim
+speaker turn jobless renewui house actonui million americans suffering click http huff 1kuzxef	__label__renewui __label__actonui
+today women equality day 94th anniversary 19th amendment proud stand women ca13 country wematter work equality remains equality means equal pay equal work affordable childcare paid family leave americans	__label__wematter __label__ca13
+buzzfeed today tremendous article state authorization use military force overly broad blank check allows president wage war time voted aumf 2001 convinced day needs repealed hear president today nsa reminded vast implications words working day repealing aumf	__label__nsa __label__aumf
+yesterday postal service announced friend mentor hero late congresswoman shirley chisholm 2014 inductee black heritage stamp series thrilled announcement trailblazer fierce advocate women rights democracy staunch opponent vietnam war read	__label__chisholm
+today president obama nominated represent congressional colleagues united nations proud represent east bay looking forward representing house colleagues 68th session general assembly united nations read statement	__label__obama
+lot going today msnbc press conference alameda county community food bank discuss unconscionable cuts weekend particularly hard snapchallenge meet friends family center food certainly hard	__label__snapchallenge
+fy15ndaa amendments readiness subcommittee language requesting gao review dod arctic capabilities february 2015 review important northern command northcom based peterson afb colorado springs language requiring dod conduct joint land use study air force academy peterson afb fort carson ensure continue enjoy good relationships surrounding community moving future language clarifying national security priority public land use	__label__fy15ndaa
+reason obamacare horrible 100 000 additional abortions year subsidized taxpayers thanks obamacare acafundsabortion scotus http www sba list org taxpayer funding aca ftn1	__label__obamacare __label__acafundsabortion __label__scotus
+government honest transparent held accountable american people yesterday house passed auditthefed think senate act	__label__auditthefed
+ohio agriculture director daniels checking corn jim dorothy leslie farm uppersandusky son jack oh5	__label__oh5 __label__ohio __label__uppersandusky
+difference suicidepreventionmonth know veteran service member crisis having thoughts suicide conversation connect free confidential support veteranscrisisline 800 273 8255 press chat online www veteranscrisisline net learn thepowerof1 www veteranscrisisline net thepowerof1	__label__veteran __label__thepowerof1 __label__veteranscrisisline __label__suicidepreventionmonth
+regulation representation ditchtherule	__label__ditchtherule
+pregnancy discrimination act amended civil rights act 1964 prohibit employment discrimination basis pregnancy took effect years ago today come long way eliminating workplace discrimination members communities face inequity daily fight discrimination work equalpay equalwork	__label__equalpay __label__equalwork
+thanks arizona governor jan brewer vetoing harmful allowed businesses refuse service lgbt community proved legislation like misguided wrong http usat 1bp7h52	__label__lgbt
+noh8onthehill repduckworth noh8campaign http yykybadi0g	__label__noh8onthehill
+kicking tour 2nd congressional district raise awareness usda summer food service program westernma endhungernow	__label__westernma __label__endhungernow
+time gop changed house rule guarantee government shutdown http talkingpointsmemo com house gop little rule change guaranteed shutdown fulfilling plan months making http www nytimes com 2013 federal budget crisis months planning html pagewanted plan culmination votes defund delay affordable care act gop members leadership continually stuck reason budging days shutdown http articles washingtonpost com 2013 politics 42692181 funds government operations government shutdown debt ceiling despite fact healthcare exchanges went effect october 1st argument clear weren getting instead gop argument started center debt ceiling http www politico com story 2013 republicans gop obamacare government shutdown debt ceiling 98102 html left chamber democratic members continually tried bring floor vote clean budget compromise reopen government budget gop proposed levels passed senate earlier year professed bipartisan support majority house http www washingtonpost com blogs post politics 2013 majority house appears support clean gop leadership refused bring floor maneuvered block member tried raising gop agreed raise debt ceiling open government compromise http www cnn com 2013 politics shutdown showdown index html utm source feedburner utm medium feed utm campaign feed rss 2fcnn allpolitics rss politics week debt ceiling agreement tied conversations fix long term deficit conversations cuts revenues http www huffingtonpost com bob greenstein government remains 4066052 html called tactic moving halfway http www slate com blogs weigel 2013 boehner meeting halfway obama wants html knows gop mistake people country children http www huffingtonpost com 2013 government shutdown wic 4073146 html military families http www cbsnews com 8301 250 162 57606695 government shutdown hitting veterans military families hard seniors http abc10up com govt shutdown stops food delivery seniors hurt shutdown impacted longer goes http thinkprogress org economy 2013 2761511 food stamps automatic cuts manufactured politically motivated crisis start end tonight gop leadership let vote clean budget let truly time story end shutdown demandavote	__label__demandavote
+joined local elected officials residents rockaways afternoon commemorate second anniversary hurricane sandy boardwalk beach 73rd street arverne	__label__sandy
+latest ebola case underscores need rigorous isolation quarantine protocols returning healthcare workers mike pintek kdka radio 1020am right tune	__label__ebola
+white house delayed certain affordable care act rules regulations 2012 elections reasons explained officials according new bombshell washington post report watch exclusive sunday interview fox news troubling revelation hear talk helping families mentalhealth crisis act reform broken mental health watch http bitly com js4f38	__label__mentalhealth
+safe reliable shalegas transforming swpa global leader energy manufacturing chemical production want turn clock energy renaissance iûªll discuss natural gas fits national energy plan town hall meeting today kdka radioûªs marcellusfest stage north click information	__label__shalegas __label__swpa __label__marcellusfest
+black friday bag cyber monday makes today givingtuesday itûªs spirit greg anchorage office giving cookies armed services ymca today group distribute yummy treats service men women single living barracks jber far away families christmas able consider giving favorite local charity alaskans holiday season little brighter pictured paulette ramage joann handy greg kaplan kim nahom	__label__givingtuesday
+heavy hearts reflect americaûªs darkest day remember firefighters ran burning buildings instead away remember faces searching loved remember flames debris fear let reflect selflessness strangers courage responders prayers echoed silence world great destruction came unwavering resolve today remember makes proud americans unshakable spirit endure greatest darkest evils neverforget	__label__neverforget
+honor kids heading school throwbackthursday getting school bus dad bus driver tbt schooldays	__label__tbt __label__throwbackthursday __label__schooldays
+california water crisis unanswered houseûªs unwavering commitment solution led california emergency drought relief act introduced congressman david valadao urgent nature water crisis house vote legislation week	__label__water
+yesterday ukrainian president petro poroshenkoûªs addressed joint session congress commend passion determination shown guiding ukraine remains difficult path restore territorial integrity country america stand ukraine defense freedom world	__label__ukraine
+today marks 224 years exceptional service men women americaûªs coastguard thank liking sharing	__label__coastguard
+rachel avino started sandy hook days died protecting students voicesofvictims http www legacy com obituaries hartfordcourant obituary aspx rachel davino pid 161726440 fbloggedout	__label__voicesofvictims
+years ûïrecovery summerû reason senate democrats act house passed jobs bills far adults left workforce new jobs obama administration ratio adults early prime working years left workforce new employment	__label__9
+things knew flag day year president proclaim flag day 1949 congress issued joint resolution stating president issue proclamation year calling national observance flag displayed federal government buildings june president obama issued year presidential proclamation flag day national flag week	__label__8
+talking chuck boozer freddi hammer morning wrhi sc05	__label__wrhi __label__sc05
+sotu	__label__sotu
+proud join congressman mark sanford introducing 3436 increase independent oversight nsa share press release 3436 nsa inspector general act 2013 washington ûò yesterday representative mark sanford republicans including rest south carolina republican delegation democrats introduced 3436 national security agency inspector general act 2013 house representatives ûïwith information continuing drip activities nsa best raise questions legality conduct worst direct violation constitution yesterday introduced legislation help correct behavior making nsa inspector general position presidential appointment confirmed senate û said sanford ûïthis process exists cia department justice department homeland security û ûïright appointed director nsa curbs oversight effectiveness director remove û added sanford ûïas recently noted cia britt snider lack independence creates environment employees igûªs office worry careers findings conclusions critical agency û ûïthere number reforms need nsa ensure agency violating privacy americans robust office reforms lack teeth need enforced vein feel legislation reasonable necessary step help bring positive change agency û representative sanford joined introducing 3436 following original sponsors listed order sponsorship paul broun mick mulvaney alan grayson kerry bentivolio tom rice eleanor holmes norton thomas massie justin amash trey gowdy jeff duncan joe wilson james sensenbrenner	__label__nsa
+catch freedomworks tap tonight 00pm matt kibbe talking syria click link watch livestream	__label__syria
+great time 2014 values voter summit weekend great running friends josh duggar congressman marlin stutzman vvs14	__label__vvs14
+great showing fl18 community support today event honoring life andrew red harris legacy promoting artificial reefs benefit marine environment loved	__label__fl18
+great stop fl18 jobs tour today visited maverick boat company official page fort pierce	__label__fl18
+congratulations julia roberts jensen beach high school year fl18 congressional art competition winner	__label__fl18
+hereûªs highlights weûªve passed week stopgovtabuse foia oversight implementation act makes easier request information holds government agencies accountable requests taxpayers right know act provides taxpayers annual report disclosing cost performance government programs list duplicative programs taxpayer transparency efficient audit act requires irs respond taxpayer inquiries days protecting taxpayers intrusive irs requests act prohibits irs religion politics social beliefs list click	__label__stopgovtabuse
+june 19th 1865 slaves galveston texas finally got word emancipation proclamation today juneteenth day commemorate celebrate end slavery america	__label__juneteenth
+tonight took important step rein potus immigration overreach fix bordercrisis http olson house gov latest news olson votes stop presidents defacto amnesty plan address border crisis	__label__bordercrisis
+obamacare forces health insurers pay fee premiums policies sold hidden tax passed consumers forcing small businesses raise premiums lay employees nfib predicts tax kill 146 000 jobs brokenpromises http tinyurl com mxrthwt	__label__obamacare __label__brokenpromises
+leader clean energy job growth pro growth policies support true energy effort boosts economy 4jobs http tinyurl com po7hey4	__label__4jobs
+potus takes credit high oil production private land drilling fed lands domestic drilling strengthen economy 4jobs http tinyurl com c9sye7w	__label__4jobs
+113th congress sworn today critically important work ahead honored represent 22nd district texas tx22	__label__tx22
+held lgbt leaders discuss issues facing community lot work order achieve equality	__label__equality __label__nj __label__lgbt
+today 79th anniversary socialsecurity critical socialsafetynet millions hard working americans protect	__label__socialsecurity __label__socialsafetynet
+new poll wall street journal shows majority americans support new environmental protection agency carbon pollution standards wsj com 1ls5a3c actonclimate	__label__actonclimate
+years ago today hank aaron beat babe ruthûªs homerun record 715 legend courage face racism hero	__label__715
+sunny day brought large crowd south amboy patrick day parade today got march mayor henry council	__label__nj
+issues raising minimum wage paid sick leave income inequality new jersey working families alliance leading fight fairness garden state icymi great article star ledger hardworking new jerseyans http bit 1kkupel	__label__icymi __label__inequality
+bhm heroine mamie clark psychologist activist research helped end racial segregation schools bit 1nxhekj	__label__bhm
+hours away gopshutdown republicansûª dysfunction refusal extreme ideological demands taking country dangerous partisan path hurt economy threaten job creation leave families security country certainty stability	__label__gopshutdown
+today joined great falls national historical park superintendent darren boch students paterson school unveiling newly renovated piece land great falls enjoy thanks hard work passaic valley sewerage commission marks step forward making prized national historical resource jewel national park	__label__28 __label__7
+morning joined democratic whip steny hoyer press conference highlight house democratsûª focus creating jobs america agenda senate republicans spent morning blocking legislationûóthe bringjobshome actûóthat help bring high paying manufacturing jobs shores afternoon house republicans attempt sue president partisan lawsuit simply wasting time taxpayer money instead focusing real problems facing country couldnûªt pick better example differences priorities looking whatûªs going congress today	__label__bringjobshome
+applaud president obamaûªs leadership netneutrality internet belong wealthy connected open space innovation entrepreneurship communication level playing field success founded best ideas deepest pockets strong rules protect consumer innovators safeguard fair fast equal access internet http goo ynocj2	__label__netneutrality
+confess pleasantly surprised paper morning filing away ûïheadlines america wishes true û aprilfoolsday	__label__aprilfoolsday
+today 1988 president reagan signed civil liberties act law bipartisan legislation condemned internment japanese americans wwii offered reparations held camps lead sponsors legislation senator alan simpson congressman norman mineta met 1943 simpsonûªs boy scout troop visited camp mineta interned colorado governor ralph carr voices opposition internment famously said harm harm brought small town knew shame dishonor race hatred grew despise threatened happiness governor carrûªs voice remained minority time legacy civil liberty advocacy celebrated today	__label__colorado
+tbt daughter briana took start college career today amazing fast time flies	__label__tbt
+obamacare means higher costs coverage obama admin lie year turning rapidly turning lies year	__label__obamacare
+hey senator bob corker senator menendez waiting standwithisraelact read http www paul senate gov press release 1193	__label__standwithisraelact
+throwback thursday brothers ronnie robert tbt	__label__tbt
+proud join humanity africa bringbackourgirls rally weekend continued pressure nigerian government international community act fast release nigerian girls kidnapped boko haram months ago	__label__bringbackourgirls
+reached million mark number people lost unemploymentinsurance including nearly 125 000 new jerseyans house republican leadership refused bring vote giving tell house republicans want extend unemployment insurance renewui	__label__unemploymentinsurance __label__renewui
+nonpartisan government accountability office confirms administration broke law released taliban commanders exchange captured soldier properly consulting congress matter leader isis american detainee released actions consequences http wapo xfjxjb	__label__isis
+joining fox news radio today talk house efforts restore balance power constitution listen live http bit 1cs6xay	__label__constitution
+human trafficking major problem end week house voted bills endtrafficking	__label__endtrafficking
+today honor fallen heroes lost september 2001 neverforget	__label__neverforget
+join praying safe speedy return north carolina air national guard 145th airlift wing true honorable patriots http usa gov tjrrqh pray	__label__pray
+hope president join year real action ûò empowering people ûò making lives harder unprecedented spending higher taxes fewer jobs cathy mcmorris rodgers gop sotu response	__label__sotu
+obamacare bad medicine	__label__obamacare
+stand lady michelle obama encourage students reach higher pursue higher education congrats students attending university wisconsin madison fall need help locating student financial aid services visit website http usa gov 1fbkebj reachhigher	__label__reachhigher
+visited america biofuels research facility sorrento valley today addition hands time lab spoke 100 local employees region continues lead way innovative energy solutions future	__label__biofuels
+feb 10th 5pm world famous apollotheater host free open house weekend celebration blackhistorymonth	__label__blackhistorymonth
+press advisory marcorubio roslehtinen mariodb hold press conf obama admin unilateral action cuba http 0swtaiyz4q	__label__obama __label__cuba
+king abdullah rhcjo jordanûªs key ally fight isil honor speak joembassyus http ft6eqwjg0g	__label__isil __label__jordans
+thx veterans fought freedom thank sacrifice veteransday http q4vtc8ktxn	__label__veterans __label__freedom __label__veteransday
+hamas capabilities financed jschanzer afpc org stevenacook followfdd http ligihdzf1o	__label__hamas
+hable pedaleabernie radiomambi710 sbr voto sin consecuencia mariela castro parlamento falso cubano otro cuento del rì©gimen	__label__cubanoes __label__castro
+lucha por una cuba libre descansa mariodb lincolndbalart cubasindicatos http lrqizwpzs5	__label__cuba
+high schooler marcel bozasûªs ûïiconic boardingû finalist art cac2014 http 2pxmsopyiy	__label__art __label__cac2014
+security council failure add cuban names violators list despite overwhelming evidence spineless http scahgdqlr4	__label__un __label__cuban
+americateve dije tenemos seguir apoyando estado judì democrìático israel contra varias amenazas http mth9bjd4a4	__label__israel
+wiod said arrests 100 damasdblanco castro shows determination silence cuba democracy movement http l2a3uet0as	__label__cubas __label__democracy __label__castro
+humbled 1st hispanic woman congress glad women hispanics public service atlanticwow http nk3clvjinu	__label__atlanticwow
+watch live mena subcmte hrng libyaûªs deteriorating security situation repteddeutch statedept deptofdefense http fazvxrnpit	__label__mena __label__libyas
+dije ernestorios786 momento crì tico para pueblo venezolano debemos apoyarlos sosvzla noticiascaracol http 8aywxlcdtt	__label__sosvzla
+maduro thugs shld sanctioned repression passed house sosvzla mcclatchydc http aeui13kd6t	__label__maduros __label__sosvzla
+discussed common regional threats like iran nuke threat assad murderous regime syria uaeembassyus http s3f3frxprf	__label__assads __label__syria __label__iran __label__nuke
+intdemocratic spoke assault democracy autocrats cuba venezuela nicaragua bolivia ecuador http ll5avbc52m	__label__democracy __label__ecuador __label__venezuela __label__bolivia __label__nicaragua __label__cuba
+whatûªs passover mean jews gather retell commemorate israelites exodus egypt whyûªs 2night different frm	__label__egypt __label__passover __label__jews __label__exodus __label__israelites
+mariodb dijimos micheljmartelly que haiti tiene que apoyar libertad cuba venezuela http 54nbxage81	__label__libertad __label__haiti __label__venezuela __label__cuba
+excited participate aipac policyconference aipac14 iamproisrael http y7vdguci9x	__label__aipac14 __label__policyconference __label__iamproisrael
+stand liberty democracy supporting ppl venezuela repressive maduro regime wiod	__label__venezuela __label__maduro __label__democracy __label__liberty
+interested free health screening join mdcollege medical campus community health fair sat feb mdc miami http ic6beesmg0	__label__mdc __label__miami
+desafortunadamente venezolanos han muerto por protestar rì©gimen abusivo maduro robertortejera cnnlatinomiami http hdgrvjqoxx	__label__maduro __label__venezolanos
+hablì© telemundo51 sobre huelga hambre antunezcuba hì©roes lucha contra castro libertad cuba http wsjyh8k8f7	__label__libertad __label__cuba __label__castro
+asked statedept abt status iragi jewish archives campliberty alqaeda resurgence iraq outlook bleak http eqtinsy8of	__label__alqaeda __label__iragi __label__campliberty __label__jewish
+join helen marie hikers maddonline dash walklikemadd feb 30am tropical park stop drunk driving http ntnz0rifbz	__label__walklikemadd
+retweeted meredith shiner meredithshiner waronbeyonce chicagotribune republican lawmakers seek details beyonce jay cuba trip http qoimplksgs	__label__waronbeyonce
+town inaugurationweekend come visit office 2morrow frm monday frm cafe http ap29hrup	__label__inaugurationweekend
+lapoderosa670 host raquelregalado speaking abt health soflaûªs economy need jobs http w04pxx4x	__label__soflas
+greta viewers pushing sgt tahmooressi release months thank support	__label__tahmooressis
+thanks jill tahmooressi courage testifying son andrew today http usa gov yeq5zj bringbackourmarine	__label__tahmooressi __label__bringbackourmarine
+latest installment ask peter respond mail karen werle algonquin asked obamacare architect jonathan gruberûªs comments passing obamacare relied ûïstupidity american voterû ûïlack transparency û american people fooled law crafted closed doors rammed congress partisan voteûóand results disastrous result millions kicked healthcare plans seen premiums skyrocket businesses forced cut workforces thatûªs introduced legislation create independent watchdog monitor obamacare help bring needed transparency accountability presidentûªs healthcare law grubergate	__label__grubergate __label__obamacare
+approximately 400 000 people living syndrome united states millions globe today nearly 691 babies born syndrome member congressional syndrome caucus strong supporter legislation like able act helps empower children special needs live independently possible october syndrome awareness month join standing solidarity affected disorder press fight understand treat hopefully prevent syndrome dsam2014	__label__dsam2014
+great chicagotribune editorial read health care law online health insurance exchanges set open month october illinois families individuals dark pay health care exactly coverage look like 2014 trainwreck	__label__chicagotribune __label__trainwreck
+today throwback thursday thought share picture couple thanksgivings ago guess kiddo photo tbt	__label__tbt
+president act immigration	__label__immigration
+congratulations montford point marines awarded congressional gold medals longoverdue	__label__longoverdue
+reminder tomorrow kicking marthalistens town hall tour prattville look forward valuable opportunity listen ideas concerns federal government click locations http roby house gov upcomingevents	__label__marthalistens
+163m medicareadvantage cuts 2015 result obamacare keepthepromise	__label__medicareadvantage __label__keepthepromise
+iûªll live lou dobbs tonight fox business discuss latest insidious lies obamacare	__label__insidious __label__obamacare
+example ûïpass whatûªs itû ûò clearly like health insurance youûªre risk keeping repeal trainwreck	__label__trainwreck
+weekûªs republican address majority leader eric cantor touts legislation house week stopgovtabuse restore taxpayer trust http www speaker gov video weekly republican address leader cantor previews stop government abuse week	__label__stopgovtabuse
+day interested attending united states service academy help service academy day johnstown talk representatives air force academy coast guard academy merchant marine academy military academy naval academy information visit http rothfus house gov service academy nominations help 30days30ways	__label__30days30ways
+took time votes constituents az05 enjoy hearing thoughts	__label__az05
+voice american people louder voice bank accounts todayûªs supreme court decision undermines principle mccutcheon decision allow wealthiest americans ûò weûªre talking little ûïthe û influence politics means individual able contribute million political interests times current limit americans know decision comes expense everyday americans public bythepeople http bit 1myv8fc	__label__bythepeople
+incredible honor award william kott belated bronze star earned battle bulge hooah	__label__hooah
+today remember stephen siller tunnel2towers run honor responders military heroes neverforget	__label__neverforget
+partners meeting house town washington dates 1780 use today nytownoftheday	__label__nytownoftheday
+today noam levey spelled acaworks today day gotcovered	__label__acaworks __label__gotcovered
+renewing fema safer program help local students pay college serve nassau suffolk communities	__label__nassau __label__suffolk
+jobs bills passed house republicans piled senator harry reid desk like share post think senate votenow	__label__votenow
+honored join oneamerica northwest immigrant rights project mayor murray michael ramos time4relief rally continue push comprehensive immigration reform president provide expanded deportation relief stop families ripped apart timeisnow	__label__time4relief __label__timeisnow
+president executive order prohibit federal contractors discriminating individuals based sexual orientation gender identity denied rights love signed letter president march urging action issue pleased text letter http adamsmith house gov uploadedfiles federal contractor employment non discrimination letter pdf enda	__label__enda
+today 41st anniversary roevwade important continue protect woman right decisions health roe41	__label__roevwade __label__roe41
+year weûªve reduced uninsured rate adults acaworks	__label__acaworks
+looking forward watching opening ceremony tonight cheering team usa favorite event sochi	__label__sochi
+forget ca38 community office hours begin today come meet staff help resolving issues federal agency	__label__ca38
+proud louisiana ranks nation best business climate perfect roux economic growth share agree	__label__1
+obama administration try spin latest obamacare enrollment figures trainwreck http nyti l3v6z4	__label__trainwreck
+itûªs beginning look lot like christmas tbt tistheseason	__label__tbt __label__tistheseason
+neat addition az06	__label__az06
+thumbs az06 small biz job chart homegrown loyaltothesoil	__label__homegrown __label__az06 __label__loyaltothesoil
+thumbs bobby applewood pet resort great concept smallbiz az06	__label__smallbiz __label__az06
+great speaking financial services innovation coalition earlier today capital credit issues impacting	__label__az
+academy nomination paperwork monday office need help 480 946 2411 read http phsom	__label__az
+type news veterans shows respect honor service right	__label__az
+serving arizona number priority priority team works shutdown fairnessforall	__label__fairnessforall __label__shutdown
+education key kids future skillsact leapact seajobs act support stem education choiceact takes decision making away bureaucrats returns home http www goupstate com article 20140930 articles 140939964 1083 articles title sen tim scott speaks education summit spartanburg	__label__skillsact __label__seajobs __label__choiceact __label__leapact
+good luck athens high school football team tonightûªs ohio state championship game shoe congrats amazing season gobulldogs	__label__ohio __label__gobulldogs
+safe relaxing labor day weekend ohio	__label__ohio
+honored receive congressional management foundation silver mouse award today way connect communicate constituents oh15 website sure visit http stivers house gov learn assist ohio http instagram com ojdojtiq	__label__oh15 __label__ohio
+new irs û÷everything comes ûª american people need start getting answersûónot contradicting testimony http washingtonexaminer com anonymous cincinnati irs official comes article 2530001	__label__irs
+order flags flown capitol honor az09 vets recognize special occasions order	__label__az09
+happy wrightbrothersday az09 home airways thousands aviation jobs thanks orville wilbur	__label__wrightbrothersday __label__az09
+today gopurpleday worked reauthorize vawa protect women families domestic violence	__label__vawa __label__gopurpleday
+tune time join coalition prevent veteran suicide join conversation stop22aday	__label__stop22aday
+honored present verma pastor hall fame award today valle del sol profiles2014 luncheon	__label__profiles2014
+help expedite passport approval az09 residents need help passport 602 956 2285	__label__az09
+equalpayweek asked administration ensure female federal workers receive equalpay won great news women http usa gov 1kcrjij	__label__equalpayweek __label__equalpay
+working ensure arizona businesses universities like asu infrastructure protected economic shock terrorism	__label__asu
+casework team ahwatukee today pecos community center 17010 48th phoenix 11a help az09 residents issues involving federal agency	__label__az09
+thanks coming congressional town hall tempe focused social security issues affecting az09 seniors taking input washington week	__label__az09
+extreme right wing groups senator speaker ted cruz way prevent vote addressing crisis unaccompanied minors crossing southern border use vote scoring sway republicans backwards way middle class losing middleclasskeepingscore	__label__middleclasskeepingscore
+room racism nba bansterling outofbounds	__label__outofbounds __label__bansterling
+met air traffic controllers livermore municipal airport handle 800 flights day help local economy ca15	__label__ca15
+hosted veterans claim backlog town hall today pleasanton vfw hall oakland director bragg ca15	__label__pleasanton __label__ca15
+voted farmbill takes food plates poor kids endhungernow	__label__farmbill __label__endhungernow
+congress waiting room right talking immigrationreform aca innovation economy hayward	__label__aca __label__immigrationreform
+today scotus voting rights act ruling rolls backs rights enforced equal access polls fight congress	__label__scotus
+viewing paul krautmann farm near hillsboro today 8th district farm tour paul grows great variety vegetables sells farmer markets area feedingamerica mo8	__label__feedingamerica __label__mo8
+tune span headed house floor raise concerns draft general management plan national park service released week ozark national scenic riverways urge park service reject changing management practices families mo8 continue enjoying rivers offer	__label__mo8
+house representatives session voting sunday early morning hours harry reid decided entire weekend fouled reid attempts blame house representatives government shutdown house sent senate different proposals government open defunding delaying obamacare harry reid refuses communicate cooperate house members harry reid weekend work house conservatives avoid government shutdown	__label__obamacare
+good day milky ways musketeers office ftw	__label__ftw
+holiday season remind veterans ûò especially suffering unseen wounds war ûò nation live promises entered service selfie veteran remind honor sacrifice novetalone	__label__novetalone __label__selfie
+corporations aren people supreme court granting corporations rights corporation fish join corpsarentpeople campaign	__label__corpsarentpeople
+house needs stay open ûò joined colleagues speaker boehner remain session address critical issues support middleclassfirst like raising minimum wage america manufacturing	__label__middleclassfirst
+planning date apple eye apple orchards choose harvard 3dthursday	__label__harvard __label__3dthursday
+chatting lawrence mayor dan rivera expectations tonightûªs state union address	__label__lawrence
+lawrence check city july4th celebration 10pm veterans mem stadium info http bit 123nsqf 3dthursday	__label__3dthursday __label__lawrence __label__july4th
+agrees northern long eared bat dwindled blame disease habitat whitenosesyndrome http dkooi2gzkk	__label__whitenosesyndrome
+immigration reform economic necessity moral imperative family issue timeisnow cir	__label__timeisnow __label__cir
+coffee coffin4council pappas vicki famous local fav tiffanyscafe dtlv onlyindistrict1 http gqybim04z4	__label__onlyindistrict1 __label__tiffanyscafe __label__dtlv
+today small business saturday day shoppers buy local money community year event definitely helps local mom pops stay business like inland empire residents shopping small everyday business owners friends neighbors compete thrive despite presence big box stores looking businesses support head 100 businesses 100 days photo album local businesses visited past weeks buylocal shopsmall smallbizsat	__label__buylocal __label__smallbizsat __label__shopsmall
+wishing safe travels roughly hackett catholic central high school students chaperones depart tonight 41st annual march life nationûªs capital marchforlife	__label__marchforlife
+wishing new yorkers happy safe laborday let enjoy weekend honoring workers built city economy	__label__laborday __label__workers
+immigrantheritagemonth ends fort worth born raised constituent gloria shares welcomeus story	__label__welcomeus __label__immigrantheritagemonth
+immediately vawa vote speaking house floor need prevent sequester cuts allow sequester effect americans teacher layoffs indiscriminate cuts special education loss million meals seniors debilitating cuts health care military families time prevent harmful board spending cuts asking unanimous consent bring 699 balanced replace sequester includes spending cuts revenues	__label__vawa
+holding press conference est tune dems gov live rethinktheborder rgv texas cir	__label__rethinktheborder __label__texas __label__cir __label__rgv
+obamacare passed lack transparency stupidity american voter sorry	__label__obamacare
+today photo edscapitoltour offers view capitol dome construction vantage point capitol visitors center located underground east capitol cast iron original domeûªs construction late 1850s early 1860s ûò making 150 years old following decade extensive study estimated 000 cracks identified needs attention construction expected years help repair dome restoration work exterior years scaffolding placed dome base crack cast iron undergo technique called ûïlock stitch û time consuming work hand complete preserve great symbol democracy generations come	__label__edscapitoltour
+great visit ymca hopkinsville wonderful progress	__label__ymca
+know president able designate land national monument stroke pen week strong support house took action requiring public input future sites national monuments hereûªs editorial bulletin inbend common sense http www bendbulletin com opinion editorials 1931357 151 editorial monuments makes common sense changes	__label__inbend
+thank girls power purse award loved meeting future leaders tomorrow making strongsmartbold moves	__label__strongsmartbold
+troop capitol hill proud girlscouts country futureleaders grace meng rep lois frankel congresswoman dina titus rep ann kirkpatrick congresswomanebjtx30	__label__futureleaders
+tune peterûªs interview channel 3ûªs ûïyou quote meû air sunday 11am heûªll discuss partnership vermontûªs cheese makers block food drug administration banning use wood shelves aging cheese saveourcheese	__label__saveourcheese
+peter strongly supports efforts senators leahy sanders rein nsa talked initiative secret intelligence budgets transparent taxpayer	__label__nsa
+visited northern virginia community college morning thank nova mission mercy volunteers incredible dental health services provide people need	__label__nova
+happy juneteenth commemorate end slavery let continue break barriers equality facing americans	__label__juneteenth
+separate independent economic analyses year proven fundamental tax reform means economic growth higher wages jobs america iûªm pleased announce year row chairman paul ryanûªs budget resolution specifically mentions fairtax tax reform legislation congress consider http usa gov 1juccyw	__label__fairtax
+world community come eradicate isis click like share agree	__label__isis
+wonderful recognize heritage place lasalle square southbend achieving 100 tax credit occupancy	__label__southbend
+energy costs rise slow job growth disappointing president obama decided declare waroncoal impose policies hurt economy drive costs american families think leave comments	__label__waroncoal
+economy growing stock market surged ûò minimum wage workers arenûªt benefiting time raisethewage	__label__raisethewage
+listening veterans 3rd district important today vfw post 846 overland park heard veterans advisory committee issues facing discussed veteran access choice accountability act 2014 supported recently signed law new law represents major reforms improve access quality care veterans special thank vets service country informing issues	__label__846
+4th annual 3rd district job fair days away know looking employment spread word join thursday august great mall great plains job fair hour exclusively veterans job seekers dress success bring copies resume need register pay attend information visit www yoder house gov contact overland park district office 913 621 0832 yoderjobfair http youtu rtp0gjbet list uuceymn4a8kzehccafeuw9lq	__label__yoderjobfair
+great pre game read kansas city star wiggins family brothers playing university kansas wichita state university good luck today teams rockchalk	__label__rockchalk

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -22,4 +22,3 @@ sp.initFromTsv('model.tsv')
 
 print(np.array(sp.getDocVector('this\tis\ttest', '\t')))
 print(np.array(sp.getDocVector('this is test', ' ')))
-

--- a/python/test/test_predictTags.py
+++ b/python/test/test_predictTags.py
@@ -1,0 +1,22 @@
+import starwrap as sw
+import numpy as np
+
+arg = sw.args()
+arg.trainFile = './tagged_post.txt'
+arg.trainMode = 0		
+
+sp = sw.starSpace(arg)
+sp.init()
+sp.train()
+
+sp.nearestNeighbor('barack', 10)
+
+
+sp.saveModel('tagged_model')
+sp.saveModelTsv('tagged_model.tsv')
+
+
+sp.initFromSavedModel('tagged_model')
+sp.initFromTsv('tagged_model.tsv')
+
+print( sp.predictTags('barack', 4) )

--- a/python/test/test_predictTags.py
+++ b/python/test/test_predictTags.py
@@ -1,5 +1,6 @@
 import starwrap as sw
 import numpy as np
+from operator import itemgetter
 
 arg = sw.args()
 arg.trainFile = './tagged_post.txt'
@@ -19,4 +20,8 @@ sp.saveModelTsv('tagged_model.tsv')
 sp.initFromSavedModel('tagged_model')
 sp.initFromTsv('tagged_model.tsv')
 
-print( sp.predictTags('barack', 4) )
+dict_obj = sp.predictTags('barack obama', 10)
+dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = False )
+
+for tag, prob in dict_obj:
+    print( tag, prob )

--- a/python/test/test_predictTags.py
+++ b/python/test/test_predictTags.py
@@ -21,7 +21,7 @@ sp.initFromSavedModel('tagged_model')
 sp.initFromTsv('tagged_model.tsv')
 
 dict_obj = sp.predictTags('barack obama', 10)
-dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = False )
+dict_obj = sorted( dict_obj.items(), key = itemgetter(1), reverse = True )
 
 for tag, prob in dict_obj:
     print( tag, prob )

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -259,6 +259,24 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
   }
 }
 
+unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
+    args_->K = k;
+    vector<Base> query_vec;    
+    parseDoc(line, query_vec, " ");
+
+    vector<Predictions> predictions;
+    predictOne(query_vec, predictions);
+
+    unordered_map<string, float> umap;
+    
+    for (int i = 0; i < predictions.size(); i++) {
+      string tmp = printDocStr(baseDocs_[predictions[i].second]);
+      umap[ tmp ] = predictions[i].first;
+    }
+
+    return umap;
+}
+
 void StarSpace::loadBaseDocs() {
   if (args_->basedoc.empty()) {
     if (args_->fileFormat == "labelDoc") {
@@ -383,6 +401,16 @@ void StarSpace::printDoc(ostream& ofs, const vector<Base>& tokens) {
     }
   }
   ofs << endl;
+}
+
+string StarSpace::printDocStr(const vector<Base>& tokens) {
+  for (auto t : tokens) {
+    if (t.first < dict_->size()) {
+      return dict_->getSymbol(t.first);
+    }
+  }
+
+  return "__label_unk";
 }
 
 void StarSpace::evaluate() {

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -259,6 +259,7 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
   }
 }
 
+//get tag prediction for a text in a hashmap
 unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
     args_->K = k;
     vector<Base> query_vec;
@@ -273,7 +274,7 @@ unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
       string tmp = printDocStr(baseDocs_[predictions[i].second]);
       umap[ tmp ] = predictions[i].first;
     }
-    
+
     return umap;
 }
 

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -261,7 +261,7 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
 
 unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
     args_->K = k;
-    vector<Base> query_vec;    
+    vector<Base> query_vec;
     parseDoc(line, query_vec, " ");
 
     vector<Predictions> predictions;
@@ -273,7 +273,7 @@ unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
       string tmp = printDocStr(baseDocs_[predictions[i].second]);
       umap[ tmp ] = predictions[i].first;
     }
-
+    
     return umap;
 }
 

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -126,6 +126,8 @@ void StarSpace::initFromSavedModel(const string& filename) {
   // init data parser
   initParser();
   initDataHandler();
+
+    loadBaseDocs();
 }
 
 void StarSpace::initFromTsv(const string& filename) {
@@ -259,7 +261,6 @@ void StarSpace::nearestNeighbor(const string& line, int k) {
   }
 }
 
-//get tag prediction for a text in a hashmap
 unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
     args_->K = k;
     vector<Base> query_vec;
@@ -274,7 +275,6 @@ unordered_map<string, float> StarSpace::predictTags(const string& line, int k){
       string tmp = printDocStr(baseDocs_[predictions[i].second]);
       umap[ tmp ] = predictions[i].first;
     }
-
     return umap;
 }
 

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -45,7 +45,6 @@ class StarSpace {
     std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
     std::string printDocStr(const std::vector<Base>& tokens);
 
-
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -41,11 +41,17 @@ class StarSpace {
 
     void nearestNeighbor(const std::string& line, int k);
 
+
+    std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
+    std::string printDocStr(const std::vector<Base>& tokens);
+
+
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);
 
     const std::string kMagic = "STARSPACE-2018-2";
+
 
     void loadBaseDocs();
 

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -41,9 +41,10 @@ class StarSpace {
 
     void nearestNeighbor(const std::string& line, int k);
 
+
     std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
     std::string printDocStr(const std::vector<Base>& tokens); 
-
+    
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);
     void printDoc(std::ostream& ofs, const std::vector<Base>& tokens);

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -41,9 +41,8 @@ class StarSpace {
 
     void nearestNeighbor(const std::string& line, int k);
 
-
     std::unordered_map<std::string, float> predictTags(const std::string& line, int k);
-    std::string printDocStr(const std::vector<Base>& tokens);
+    std::string printDocStr(const std::vector<Base>& tokens); 
 
     void saveModel(const std::string& filename);
     void saveModelTsv(const std::string& filename);


### PR DESCRIPTION
The method predictTags will actually return an unordered_map of k predicted tags given an input text. In a separate PR (coming in a few minutes), I'll add the Python binding and a test case for this new method.