### PR TITLE
Implement python wrappers for predictions and tune speed

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -76,6 +76,7 @@ include_directories(${PROJECT_SOURCE_DIR}/pybind11/include)
 # Create the binding library
 add_library(starwrap SHARED
   starspace_pybind.cc
+  starspace_pythonic.cc
   # ... extra files go here ...
 )
 

--- a/python/build.sh
+++ b/python/build.sh
@@ -24,9 +24,9 @@ cd -
 echo "#############################  run test ############################# "
 # run test
 # this will run all wrapped APIs available at this moment.
-# by loading traing data from input.txt, train with train mode 5, 
+# by loading traing data from input.txt, train with train mode 5,
 # find nearest neighbor to some random text, save model as binary and tsv,
-# try loading both saved models above again and 
+# try loading both saved models above again and
 # generate Document Embedding for some random text.
 cp ./build/starwrap.so ./test
 cd test

--- a/python/starspace_pybind.cc
+++ b/python/starspace_pybind.cc
@@ -5,6 +5,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "starspace_pythonic.h"
+
 namespace py = pybind11;
 
 PYBIND11_MODULE(starwrap, m) {
@@ -72,22 +74,22 @@ PYBIND11_MODULE(starwrap, m) {
 		}
 	);
 
-	py::class_<starspace::StarSpace>(m, "starSpace")
+	py::class_<starspace::StarSpacePythonic>(m, "starSpace")
 		.def(py::init<std::shared_ptr<starspace::Args>>())
-		.def("init", &starspace::StarSpace::init)
-		.def("initFromTsv", &starspace::StarSpace::initFromTsv)
-		.def("initFromSavedModel", &starspace::StarSpace::initFromSavedModel)
+		.def("init", &starspace::StarSpacePythonic::init)
+		.def("initFromTsv", &starspace::StarSpacePythonic::initFromTsv)
+		.def("initFromSavedModel", &starspace::StarSpacePythonic::initFromSavedModel)
 
-		.def("train", &starspace::StarSpace::train)
-		.def("evaluate", &starspace::StarSpace::evaluate)
+		.def("train", &starspace::StarSpacePythonic::train)
+		.def("evaluate", &starspace::StarSpacePythonic::evaluate)
 
-		.def("getDocVector", &starspace::StarSpace::getDocVector)
+		.def("getDocVector", &starspace::StarSpacePythonic::getDocVector)
 
-		.def("nearestNeighbor", &starspace::StarSpace::nearestNeighbor)
-		.def("predictTags", &starspace::StarSpace::predictTags)
+		.def("nearestNeighbor", &starspace::StarSpacePythonic::nearestNeighbor)
+		.def("predictTags", &starspace::StarSpacePythonic::predictTags)
 
-		.def("saveModel", &starspace::StarSpace::saveModel)
-		.def("saveModelTsv", &starspace::StarSpace::saveModelTsv)
-		.def("loadBaseDocs", &starspace::StarSpace::loadBaseDocs)
+		.def("saveModel", &starspace::StarSpacePythonic::saveModel)
+		.def("saveModelTsv", &starspace::StarSpacePythonic::saveModelTsv)
+		.def("loadBaseDocs", &starspace::StarSpacePythonic::loadBaseDocs)
 		;
 }

--- a/python/starspace_pybind.cc
+++ b/python/starspace_pybind.cc
@@ -91,5 +91,9 @@ PYBIND11_MODULE(starwrap, m) {
 		.def("saveModel", &starspace::StarSpacePythonic::saveModel)
 		.def("saveModelTsv", &starspace::StarSpacePythonic::saveModelTsv)
 		.def("loadBaseDocs", &starspace::StarSpacePythonic::loadBaseDocs)
+
+		.def("parseDoc", &starspace::StarSpacePythonic::parseDoc)
+		.def("renderTokens", &starspace::StarSpacePythonic::renderTokens)
+		.def("predict", &starspace::StarSpacePythonic::predict)
 		;
 }

--- a/python/starspace_pythonic.cc
+++ b/python/starspace_pythonic.cc
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <boost/algorithm/string.hpp>
+
+#include "starspace_pythonic.h"
+
+using namespace std;
+
+namespace starspace {
+
+StarSpacePythonic::StarSpacePythonic(std::shared_ptr<Args> args) :
+  StarSpace(args)
+{
+}
+
+vector<Base> StarSpacePythonic::parseDoc(
+        const string& line,
+        const string& sep)
+{
+    vector<Base> ids;
+    StarSpace::parseDoc(line, ids, sep);
+    return ids;
+}
+
+vector<Predictions> StarSpacePythonic::predict(const vector<Base>& input, int k)
+{
+  vector<Predictions> out;
+  StarSpace::predict(input, out, k);
+  return out;
+}
+
+vector<vector<string>> StarSpacePythonic::renderTokens(const vector<Predictions>& predictions)
+{
+  vector<vector<string>> out;
+
+  for (auto p: predictions) {
+    vector<string> current;
+    auto tokens = baseDocs_[p.second];
+
+    for (auto t : tokens)
+      if (t.first < dict_->size())
+        current.push_back(dict_->getSymbol(t.first));
+
+    out.push_back(current);
+  }
+
+  return out;
+}
+
+} // namespace starspace end

--- a/python/starspace_pythonic.h
+++ b/python/starspace_pythonic.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <starspace.h>
+#include <parser.h>
+
+namespace starspace {
+  /**
+   * This class wraps StarSpace class to make functions more python like.
+   *
+   * C++11 allows returning complex types by value in fast manner thus dancing
+   * around with passing vectors by reference to function is not needed.
+   *
+   * The functions used here are not the same as in StarSpace class, thus
+   * no virtual modifiers for them are needed.
+   */
+
+  class StarSpacePythonic : public StarSpace
+  {
+  public:
+    explicit StarSpacePythonic(std::shared_ptr<Args> args);
+
+    std::vector<Base> parseDoc(
+        const std::string& line,
+        const std::string& sep);
+
+    // Let use fasttext compatible signature of predict function
+    std::vector<Predictions> predict(const std::vector<Base>& input, int k);
+
+    // Render response to string instead using ofstream
+    std::vector<std::vector<std::string>> renderTokens(const std::vector<Predictions>& tokens);
+  };
+}

--- a/src/starspace.cpp
+++ b/src/starspace.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <queue>
 #include <unordered_set>
+#include <set>
 
 #include <boost/algorithm/string.hpp>
 
@@ -318,19 +319,44 @@ void StarSpace::loadBaseDocs() {
 void StarSpace::predictOne(
     const vector<Base>& input,
     vector<Predictions>& pred) {
+      predict(input, pred, args_->K);
+}
+
+void StarSpace::predict(
+    const vector<Base>& input,
+    vector<Predictions>& pred,
+    int k) {
   auto lhsM = model_->projectLHS(input);
-  std::priority_queue<Predictions> heap;
-  for (unsigned int i = 0; i < baseDocVectors_.size(); i++) {
+  std::set<Predictions> predictions;
+  int docsize = baseDocVectors_.size();
+
+  // When docs are not loaded the prediction result will be empty vector
+  if (!docsize) {
+    loadBaseDocs();
+    docsize = baseDocVectors_.size();
+  }
+
+  for (unsigned int i = 0; i < docsize; i++) {
     auto cur_score = model_->similarity(lhsM, baseDocVectors_[i]);
-    heap.push({ cur_score, i });
+
+    if (predictions.size() >= k) {
+      auto smallest_element = predictions.begin();
+
+      /**
+       * Most of predictions have too low score, so we should not touch and waste
+       * CPU time for rebalancing set
+       */
+      if (cur_score < smallest_element->first)
+        continue;
+
+      predictions.erase(smallest_element);
+    }
+
+    predictions.insert({ cur_score, i });
   }
-  // get the first K predictions
-  int i = 0;
-  while (i < args_->K && heap.size() > 0) {
-    pred.push_back(heap.top());
-    heap.pop();
-    i++;
-  }
+
+  // When we finish, we have K or less predictions in set, move them to vector
+  pred.insert(pred.end(), predictions.begin(), predictions.end());
 }
 
 Metrics StarSpace::evaluateOne(

--- a/src/starspace.h
+++ b/src/starspace.h
@@ -22,6 +22,8 @@ typedef std::pair<Real, int32_t> Predictions;
 class StarSpace {
   public:
     explicit StarSpace(std::shared_ptr<Args> args);
+    // This class has derived ones for scripting languages connection
+    virtual ~StarSpace() {};
 
     void init();
     void initFromTsv(const std::string& filename);
@@ -54,6 +56,10 @@ class StarSpace {
 
     void loadBaseDocs();
 
+    void predict(
+        const std::vector<Base>& input,
+        std::vector<Predictions>& pred,
+        int k);
     void predictOne(
         const std::vector<Base>& input,
         std::vector<Predictions>& pred);
@@ -70,7 +76,6 @@ class StarSpace {
         std::vector<Predictions>& pred,
         bool excludeLHS);
 
-    std::shared_ptr<Dictionary> dict_;
     std::shared_ptr<DataParser> parser_;
     std::shared_ptr<InternDataHandler> trainData_;
     std::shared_ptr<InternDataHandler> validData_;
@@ -78,6 +83,9 @@ class StarSpace {
     std::shared_ptr<EmbedModel> model_;
 
     std::vector<Matrix<Real>> baseDocVectors_;
+
+  protected:
+    std::shared_ptr<Dictionary> dict_;
 };
 
 }


### PR DESCRIPTION
1. Predict now use std::set instead priority_queue. From my point of
view it is better to maintain set of fixed size and drop predictions
with too low score immideately instead storing them in ordered manner.
2. Implemented extension class of StarSpace to make things a bit more
pythonic. It is definitely better to have return value instead of
passing parameters to fill to functions. From my point of view, speed is
not changed in case modern C++ compilers handle return of complex values
properly without copying them.