### PR TITLE
Fix duplicate results when doing prediction

### DIFF
--- a/src/apps/query_predict.cpp
+++ b/src/apps/query_predict.cpp
@@ -29,6 +29,8 @@ int main(int argc, char** argv) {
   StarSpace sp(args);
   if (boost::algorithm::ends_with(args->model, ".tsv")) {
     sp.initFromTsv(args->model);
+    // Load basedocs which are set of possible things to predict.
+    sp.loadBaseDocs();
   } else {
     sp.initFromSavedModel(args->model);
     cout << "------Loaded model args:\n";
@@ -37,8 +39,6 @@ int main(int argc, char** argv) {
   // Set dropout probability to 0 in test case.
   sp.args_->dropoutLHS = 0.0;
   sp.args_->dropoutRHS = 0.0;
-  // Load basedocs which are set of possible things to predict.
-  sp.loadBaseDocs();
 
   for(;;) {
     string input;


### PR DESCRIPTION
Fixes: https://github.com/facebookresearch/StarSpace/issues/280

This fixes the problem with duplicate results when doing prediction due to `loadBaseDocs` been called twice. Once in `initFromSavedModel` and once in `loadBaseDocs`. This will generate duplicate entries in `baseDocVectors_` which will be a problem in `predictOne`