### PR TITLE
Upgrade pybind

### DIFF
--- a/python/conanfile.txt
+++ b/python/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-pybind11/2.2.4@conan/stable
+pybind11/2.4.3@conan/stable
 
 [generators]
 cmake

--- a/python/conanfile.txt
+++ b/python/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-pybind11/2.4.3@conan/stable
+pybind11/2.4.3
 
 [generators]
 cmake


### PR DESCRIPTION
Conan's minimal pybind version seems to be this one in the PR and also due to some internal changes it can't be found if we specify the stable channel (they changed from bintray).
